### PR TITLE
Update dependency to rails 3.2.11

### DIFF
--- a/data_migrate.gemspec
+++ b/data_migrate.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "data_migrate"
 
-  s.add_dependency('rails', '>= 3.0.0', '<= 3.0.11')
+  s.add_dependency('rails', '>= 3.0.0', '<= 3.2.11')
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Hi,

We changed the rails version dependency to version 3.2.11 and we have done some tests (db:migrate, db:migrate:with_data, db:rollback, db:rollback:with_data, data:version,...) and all seems to work properly.

If you consider to accept this pull request it will be great for us.

Regards,
Gabriel Ramos
