### PR TITLE
Documentation for rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ If you need a data only migration, either run it as such, with the skip-schema-m
 
     $> rake -T data
     rake data:forward                 # Pushes the schema to the next version (specify steps w/ STEP=n).
+    rake data:migrate                 # Migrate the database through scripts in db/data.
     rake data:migrate:down            # Runs the "down" for a given migration VERSION.
     rake data:migrate:redo            # Rollbacks the database one migration and re migrate up (options: STEP=x, VERSION=x).
     rake data:migrate:status          # Display status of data migrations

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -204,8 +204,8 @@ namespace :db do
   end
 
   namespace :version do
-    desc "Retrieves the current schema version numbers for data and schema migrations"
     task :with_data => :environment do
+    desc "Retrieves the current schema version numbers for data and schema migrations"
       assure_data_schema_table
       puts "Current Schema version: #{ActiveRecord::Migrator.current_version}"
       puts "Current Data version: #{DataMigrate::DataMigrator.current_version}"
@@ -214,6 +214,7 @@ namespace :db do
 end
 
 namespace :data do
+  desc 'Migrate the database through scripts in db/data'
   task :migrate => :environment do
     assure_data_schema_table
     ActiveRecord::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true


### PR DESCRIPTION
Hi,

In documentantion file (README.md) there is information about a db:migrate:data task that does not exists.

Looking into the database.rake file I found a data:migrate task that seems to be the real task that the documentation refers.

I have changed both files to correct this situation.

If those changes are not correct, please discard this request.

Regards
Gabi
