### PR TITLE
fix data migration template

### DIFF
--- a/lib/generators/data_migration/templates/data_migration.rb
+++ b/lib/generators/data_migration/templates/data_migration.rb
@@ -3,6 +3,6 @@ class <%= migration_class_name %> < ActiveRecord::Migration
   end
 
   def self.down
-    raise IrreversibleMigration
+    raise ActiveRecord::IrreversibleMigration
   end
 end


### PR DESCRIPTION
since Rails 3.2 IrreversibleMigration class moved to ActiveRecord
namespace
