### PR TITLE
Using db:migrate:with_data does not load data migrations / db and data migrations with the same name

### DIFF
--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -16,7 +16,7 @@ module DataMigrate
         unless  options.skip_schema_migration?
           migration_template "migration.rb", "db/migrate/#{file_name}.rb"
         end
-        migration_template "data_migration.rb", "db/data/#{file_name}.rb"
+        migration_template "data_migration.rb", "db/data/#{file_name}_data_migration.rb"
       end
 
       protected


### PR DESCRIPTION
Hi,

Using ```rake db:migrate:with_data``` ends with an error in my project. 

While researching this issue I've found out that problem exists with db and data migrations which have same name. Rails migration generator [checks if name is not taken](https://github.com/rails/rails/blob/3-2-stable/railties/lib/rails/generators/migration.rb#L58-60) and migrator [requires file](https://github.com/rails/rails/blob/cdda29051a4d1216288f06bacfc05da59fcdb40b/activerecord/lib/active_record/migration.rb#L756-763) and [loads it's method](https://github.com/rails/rails/blob/cdda29051a4d1216288f06bacfc05da59fcdb40b/activerecord/lib/active_record/migration.rb#L555-565). So, migrating both db and data migrations in one task causes db migration to be run twice.

You can check issue example [here](https://github.com/XmmmiR/data-migrate-issue).