### PR TITLE
Store current state of model for running data migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 /.rvmrc
+Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ If you need a data only migration, either run it as such, with the skip-schema-m
 
     rails g data_migration add_this_to_that --skip-schema-migration
 
+A shorter alias for this is -m:
+
+    rails g data_migration add_this_to_that -m
+
 To ensure backwards compatibility, you should inform data-migrate which classes will be used
 in the migration. data-migrate will create a secondary file recording the current
 state of those model classes and will ensure that whenever the migration is run,

--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ If you need a data only migration, either run it as such, with the skip-schema-m
 
     rails g data_migration add_this_to_that --skip-schema-migration
 
+To ensure backwards compatibility, you should inform data-migrate which classes will be used
+in the migration. data-migrate will create a secondary file recording the current
+state of those model classes and will ensure that whenever the migration is run,
+the classes will be correct.
+
+    rails g data_migration add_this_to_that --classes=User Credential Email
 
 ### Rake Tasks
 

--- a/README.md
+++ b/README.md
@@ -117,15 +117,30 @@ the classes will be correct.
 
     rails g data_migration add_this_to_that --classes=User Credential Email
 
+### Required Migrations
+
+You can specify certain migrations as being "required" - the idea is that these
+need to run before the app can come up, while normal migrations can run
+once the deploy is finished. These will show up
+in db/required_data instead of in db/data, though the version will still be
+stored in the same data_migrations table. Running rake data:migrate normally
+will only run *non-required* migrations (this seems backwards but this is done
+because required migrations are rare.
+
+There is no real difference between required and non/required - it's just an
+easy way to differentiate two different types of data migrations.
+
 ### Rake Tasks
 
     $> rake -T data
     rake data:forward                 # Pushes the schema to the next version (specify steps w/ STEP=n)
-    rake data:migrate                 # Migrate data migrations (options: VERSION=x, VERBOSE=false)
+    rake data:migrate                 # Migrate non-required data migrations (options: VERSION=x, VERBOSE=false)
     rake data:migrate:down            # Runs the "down" for a given migration VERSION
     rake data:migrate:redo            # Rollbacks the database one migration and re migrate up (options: STEP=x, VERSIO...
     rake data:migrate:status          # Display status of data migrations
     rake data:migrate:up              # Runs the "up" for a given migration VERSION
+    rake data:migrate:required        # Run "required" migrations
+    rake data:migrate:all             # Run both required and normal migrations
     rake data:rollback                # Rolls the schema back to the previous version (specify steps w/ STEP=n)
     rake data:version                 # Retrieves the current schema version number for data migrations
     rake db:forward:with_data         # Pushes the schema to the next version (specify steps w/ STEP=n)

--- a/data_migrate.gemspec
+++ b/data_migrate.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |s|
   s.name        = "data_migrate"
   s.version     = DataMigrate::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Andrew J Vargo"]
-  s.email       = ["ajvargo@computer.org"]
+  s.authors     = ["Andrew J Vargo", "Daniel Orner"]
+  s.email       = ["ajvargo@computer.org", "daniel.orner@wishabi.com"]
   s.homepage    = "http://ajvargo.com"
   s.summary     = %q{Rake tasks to migrate data alongside schema changes.}
   s.description = %q{Rake tasks to migrate data alongside schema changes.}

--- a/data_migrate.gemspec
+++ b/data_migrate.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "data_migrate"
 
-  s.add_dependency('rails', '>= 3.1.0')
+  s.add_dependency('rails', '>= 3.0.0')
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/data_migrate/data_migrator.rb
+++ b/lib/data_migrate/data_migrator.rb
@@ -8,7 +8,7 @@ module DataMigrate
       end
 
       def migrations_path
-        'db/data'
+        ENV['REQUIRED_DATA_MIGRATIONS'] ? 'db/required_data' : 'db/data'
       end
     end
   end

--- a/lib/data_migrate/version.rb
+++ b/lib/data_migrate/version.rb
@@ -1,3 +1,3 @@
 module DataMigrate
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end

--- a/lib/data_migrate/version.rb
+++ b/lib/data_migrate/version.rb
@@ -1,3 +1,3 @@
 module DataMigrate
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end

--- a/lib/data_migrate/version.rb
+++ b/lib/data_migrate/version.rb
@@ -1,3 +1,3 @@
 module DataMigrate
-  VERSION = "1.2.2"
+  VERSION = "1.2.3"
 end

--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -15,13 +15,17 @@ module DataMigrate
       class_option :classes,
                    :desc => 'Classes that will be used in the data migration',
                    :type => :array
+      class_option :required, :desc => 'Mark this as a "required" migration.'
 
       def create_data_migration
+        if options.required?
+          ENV['REQUIRED_DATA_MIGRATIONS'] = 'true'
+        end
         set_local_assigns!
         unless options.skip_schema_migration?
           migration_template "migration.rb", "db/migrate/#{file_name}.rb"
         end
-        migration_template "data_migration.rb", "db/data/#{file_name}.rb"
+        migration_template "data_migration.rb", "#{DataMigrate::DataMigrator.migrations_path}/#{file_name}.rb"
         if options.classes
           options.classes.each do |class_name|
             klass = class_name.constantize
@@ -33,7 +37,7 @@ module DataMigrate
             end
           end
           migration_template "migration_include.rb",
-                             "db/data/includes/#{file_name}.rb"
+                             "#{DataMigrate::DataMigrator.migrations_path}/includes/#{file_name}.rb"
         end
       end
 

--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -10,13 +10,20 @@ module DataMigrate
 
       argument :attributes, :type => :array, :default => [], :banner => "field:type field:type"
       class_option :skip_schema_migration, :desc => 'Dont generate database schema migration file.', :type => :boolean
+      class_option :classes,
+                   :desc => 'Classes that will be used in the data migration',
+                   :type => :array
 
       def create_data_migration
         set_local_assigns!
-        unless  options.skip_schema_migration?
+        unless options.skip_schema_migration?
           migration_template "migration.rb", "db/migrate/#{file_name}.rb"
         end
         migration_template "data_migration.rb", "db/data/#{file_name}.rb"
+        if options.classes
+          migration_template "migration_include.rb",
+                             "db/data/includes/#{file_name}.rb"
+        end
       end
 
       protected

--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -9,7 +9,9 @@ module DataMigrate
       include Rails::Generators::Migration
 
       argument :attributes, :type => :array, :default => [], :banner => "field:type field:type"
-      class_option :skip_schema_migration, :desc => 'Dont generate database schema migration file.', :type => :boolean
+      class_option :skip_schema_migration,
+                   :aliases => '-m',
+                   :desc => 'Dont generate database schema migration file.', :type => :boolean
       class_option :classes,
                    :desc => 'Classes that will be used in the data migration',
                    :type => :array

--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -23,6 +23,15 @@ module DataMigrate
         end
         migration_template "data_migration.rb", "db/data/#{file_name}.rb"
         if options.classes
+          options.classes.each do |class_name|
+            klass = class_name.constantize
+            while klass.superclass != ActiveRecord::Base
+              klass = klass.superclass
+              unless options.classes.include?(klass.name)
+                options.classes.unshift(klass.name)
+              end
+            end
+          end
           migration_template "migration_include.rb",
                              "db/data/includes/#{file_name}.rb"
         end

--- a/lib/generators/data_migration/templates/data_migration.rb
+++ b/lib/generators/data_migration/templates/data_migration.rb
@@ -1,8 +1,10 @@
+<% if options.classes.present? %>require_relative '<%= "includes/#{@migration_number}_#{@migration_file_name}.rb" %>'
+<% end %>
 class <%= migration_class_name %> < ActiveRecord::Migration
   def self.up
   end
 
   def self.down
-    raise ActiveRecord::IrreversibleMigration
+    raise <%= defined?(IrreversibleMigration) ? 'IrreversibleMigration' : 'ActiveRecord::IrreversibleMigration' %>
   end
 end

--- a/lib/generators/data_migration/templates/migration_include.rb
+++ b/lib/generators/data_migration/templates/migration_include.rb
@@ -1,5 +1,6 @@
 <% options.classes.each do |class_name| %>class <%= class_name %> < <%= class_name.constantize.superclass.name %>
-<% class_name.constantize.reflect_on_all_associations.each do |assoc| %>  <%= assoc.macro %> :<%= assoc.name %>, <%= assoc.options %>
+  set_table_name '<%= class_name.constantize.table_name %>'
+<% class_name.constantize.reflect_on_all_associations.each do |assoc| %>  <%= assoc.macro %> :<%= assoc.name %>, <%= assoc.options.to_s %>
 <% end %>end
 
 <% end %>

--- a/lib/generators/data_migration/templates/migration_include.rb
+++ b/lib/generators/data_migration/templates/migration_include.rb
@@ -1,0 +1,5 @@
+<% options.classes.each do |class_name| %>class <%= class_name %> < ActiveRecord::Base
+<% class_name.constantize.reflect_on_all_associations.each do |assoc| %>  <%= assoc.macro %> :<%= assoc.name %>, <%= assoc.options %>
+<% end %>end
+
+<% end %>

--- a/lib/generators/data_migration/templates/migration_include.rb
+++ b/lib/generators/data_migration/templates/migration_include.rb
@@ -1,4 +1,4 @@
-<% options.classes.each do |class_name| %>class <%= class_name %> < ActiveRecord::Base
+<% options.classes.each do |class_name| %>class <%= class_name %> < <%= class_name.constantize.superclass.name %>
 <% class_name.constantize.reflect_on_all_associations.each do |assoc| %>  <%= assoc.macro %> :<%= assoc.name %>, <%= assoc.options %>
 <% end %>end
 

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -216,12 +216,36 @@ end
 namespace :data do
   desc 'Migrate data migrations (options: VERSION=x, VERBOSE=false)'
   task :migrate => :environment do
+    ENV['REQUIRED_DATA_MIGRATIONS'] = nil
     assure_data_schema_table
     ActiveRecord::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
     DataMigrate::DataMigrator.migrate(DataMigrate::DataMigrator.migrations_path, ENV["VERSION"] ? ENV["VERSION"].to_i : nil)
   end
 
   namespace :migrate do
+
+    desc 'Migrate required data migrations.'
+    task :required => :environment do
+      ENV['REQUIRED_DATA_MIGRATIONS'] = 'true'
+      assure_data_schema_table
+      ActiveRecord::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
+      DataMigrate::DataMigrator.migrate(DataMigrate::DataMigrator.migrations_path, ENV["VERSION"] ? ENV["VERSION"].to_i : nil)
+    end
+
+    desc 'Migrate both required and non-required data migrations.'
+    task :all => :environment do
+
+      ENV['REQUIRED_DATA_MIGRATIONS'] = 'true'
+      assure_data_schema_table
+      ActiveRecord::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
+      DataMigrate::DataMigrator.migrate(DataMigrate::DataMigrator.migrations_path, ENV["VERSION"] ? ENV["VERSION"].to_i : nil)
+
+      ENV['REQUIRED_DATA_MIGRATIONS'] = nil
+      assure_data_schema_table
+      ActiveRecord::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
+      DataMigrate::DataMigrator.migrate(DataMigrate::DataMigrator.migrations_path, ENV["VERSION"] ? ENV["VERSION"].to_i : nil)
+    end
+
     desc  'Rollbacks the database one migration and re migrate up (options: STEP=x, VERSION=x).'
     task :redo => :environment do
       assure_data_schema_table


### PR DESCRIPTION
The one thing, oddly enough, that this gem does *not* fix is the changing model problem. For example, in your description in the readme of a Post for which the Comment is removed, once the Comment model is gone, you will no longer be able to use it in the data migration! So while this gem organizes the scripts, it doesn't fix the overarching mutability issue.

This pull request creates a secondary file which is included in the data migration. This sets the associations of all used models (using a --classes option) so when they are referenced in the data migration, all the associations will magically work even if the model has been changed or removed in the meantime.