### PR TITLE
Add schema load initialization

### DIFF
--- a/data_migrate.gemspec
+++ b/data_migrate.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "data_migrate"
 
-  s.add_dependency('rails', '>= 3.1.0')
+  s.add_dependency('rails', '>= 3.0.10')
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -1,3 +1,5 @@
+ActiveRecord::SchemaDumper.ignore_tables << DataMigrate::DataMigrator.schema_migrations_table_name
+
 namespace :db do
   namespace :migrate do
     desc "Migrate the database data and schema (options: VERSION=x, VERBOSE=false)."


### PR DESCRIPTION
Hi, thanks for this gem!

I'd like to get your feedback on a couple of things, and hope to get this pull-request merged in, if possible.

1.  According to the commit history, the rails dependency on 3.1.0 was due to the location of `IrreversibleMigration`, but when I checked, that class has not moved from 3.0.0 to 4.1.0.  In the PR, I've moved it back to 3.0.10

2. I added some code to populate the data_migrations table on `db:schema:load` to avoid running data migration code in a system that should not need it.  This is similar to how schema migrations don't run after a `db:schema:load` because the schema_migrations is pre-populated with all the migrations up to the version specified in the schema.rb.

Thanks!