### PR TITLE
Multiple db migrations

### DIFF
--- a/lib/data_migrate/data_migrator.rb
+++ b/lib/data_migrate/data_migrator.rb
@@ -10,6 +10,27 @@ module DataMigrate
       def migrations_path
         'db/data'
       end
+
+      def assure_data_schema_table
+        config = ActiveRecord::Base.configurations[Rails.env || 'development'] || ENV["DATABASE_URL"]
+        ActiveRecord::Base.establish_connection(config)
+        sm_table = DataMigrate::DataMigrator.schema_migrations_table_name
+
+        unless ActiveRecord::Base.connection.table_exists?(sm_table)
+          ActiveRecord::Base.connection.create_table(sm_table, :id => false) do |schema_migrations_table|
+            schema_migrations_table.column :version, :string, :null => false
+          end
+
+          suffix = ActiveRecord::Base.table_name_suffix
+          prefix = ActiveRecord::Base.table_name_prefix
+          index_name = "#{prefix}unique_data_migrations#{suffix}"
+
+          ActiveRecord::Base.connection.add_index sm_table, :version,
+            :unique => true,
+            :name => index_name
+        end
+      end
+
     end
   end
 end

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -312,11 +312,16 @@ def pending_migrations
 end
 
 def pending_data_migrations
-  sort_migrations DataMigrate::DataMigrator.new(:up, 'db/data').pending_migrations.map{|m| { :version => m.version, :kind => :data }}
+  data_migrations = DataMigrate::DataMigrator.migrations('db/data')
+  sort_migrations DataMigrate::DataMigrator.new(:up, data_migrations ).
+    pending_migrations.map{|m| { :version => m.version, :kind => :data }}
 end
 
 def pending_schema_migrations
-  sort_migrations ActiveRecord::Migrator.new(:up, 'db/migrate').pending_migrations.map{|m| { :version => m.version, :kind => :schema }}
+  all_migrations = ActiveRecord::Migrator.migrations(Rails.application.config.paths["db/migrate"])
+  sort_migrations(ActiveRecord::Migrator.new(:up, all_migrations ).
+    pending_migrations.
+    map{|m| { :version => m.version, :kind => :schema }})
 end
 
 def sort_migrations set_1, set_2=nil

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -358,14 +358,5 @@ def past_migrations sort=nil
 end
 
 def assure_data_schema_table
-  config = ActiveRecord::Base.configurations[Rails.env || 'development'] || ENV["DATABASE_URL"]
-  ActiveRecord::Base.establish_connection(config)
-  sm_table = DataMigrate::DataMigrator.schema_migrations_table_name
-
-  unless ActiveRecord::Base.connection.table_exists?(sm_table)
-    ActiveRecord::Base.connection.create_table(sm_table, :id => false) do |schema_migrations_table|
-      schema_migrations_table.column :version, :string, :null => false
-    end
-    ActiveRecord::Base.connection.add_index sm_table, :version, :unique => true, :name => "#{ActiveRecord::Base.table_name_prefix}unique_data_migrations#{ActiveRecord::Base.table_name_suffix}"
-  end
+  DataMigrate::DataMigrator.assure_data_schema_table
 end

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -49,7 +49,11 @@ namespace :db do
           DataMigrate::DataMigrator.run(migration[:direction], "db/data/", migration[:version])
         else
           ActiveRecord::Migration.write("== %s %s" % ['Schema', "=" * 69])
-          ActiveRecord::Migrator.run(migration[:direction], "db/migrate/", migration[:version])
+          ActiveRecord::Migrator.run(
+            migration[:direction],
+            Rails.application.config.paths["db/migrate"],
+            migration[:version]
+          )
         end
       end
 
@@ -319,7 +323,8 @@ end
 
 def pending_schema_migrations
   all_migrations = ActiveRecord::Migrator.migrations(Rails.application.config.paths["db/migrate"])
-  sort_migrations(ActiveRecord::Migrator.new(:up, all_migrations ).
+  sort_migrations(
+    ActiveRecord::Migrator.new(:up, all_migrations).
     pending_migrations.
     map{|m| { :version => m.version, :kind => :schema }})
 end


### PR DESCRIPTION
Some rails applications store database schema changes files in different directories, in order to do that `Rails.application.config.paths["db/migrate"]` needs to be configured appropriately [1]. This PR make updates to `data-migrate` to work with such projects. Also introducing some cleanup to the code 
 
[1] https://blog.pivotal.io/labs/labs/leave-your-migrations-in-your-rails-engines