### PR TITLE
Fix data migration table

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Going down instead of up would be the opposite.
 
 Thanks
 ------
-[Andrew J Vargo](github.com/ajvargo) Andrew was the original creator and maintainer of this project!
+[Andrew J Vargo](http://github.com/ajvargo) Andrew was the original creator and maintainer of this project!
 
 [Jeremy Durham](http://jeremydurham.com/) for fleshing out the idea with me, and providing guidance.
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,23 @@ schema and data migrations in the proper order.
 
 Note: If a data and schema migration share the same version number, schema gets precedence when migrating up. Data does down.
 
-Rails 3 and Ruby 1.9
+Rails Support
 --------------------
 
-Data Migrate is Rails 3 and Ruby 1.9 compatible.
+Rails 3.1: Version 1.2 supports Rails 3.1.0 and higher **but** is not longer maintained.
+
+Rails 4: Version 2.0 supports Rails 4.0 and higher
+
+Rails 5: Not tested
+
+### Important note
+
+If you upgraded to Rails 4 while using `data_migrate` prior to version 2,
+the gem wrote data migration versions into
+`schema_migrations` table. After the fix, it was corrected to write into
+`data_migrations`.
+
+This may cause some unintended consequences. See [#22](https://github.com/ilyakatz/data-migrate/issues/22)
 
 Installation
 ------------
@@ -105,7 +118,6 @@ This allows you to do things like:
 If you need a data only migration, either run it as such, with the skip-schema-migration flag:
 
     rails g data_migration add_this_to_that --skip-schema-migration
-
 
 ### Rake Tasks
 

--- a/data_migrate.gemspec
+++ b/data_migrate.gemspec
@@ -6,15 +6,15 @@ Gem::Specification.new do |s|
   s.name        = "data_migrate"
   s.version     = DataMigrate::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Andrew J Vargo"]
-  s.email       = ["ajvargo@computer.org"]
+  s.authors     = ["Andrew J Vargo", "Ilya Katz"]
+  s.email       = ["ajvargo@computer.org", "ilyakatz@gmail.com"]
   s.homepage    = "http://ajvargo.com"
   s.summary     = %q{Rake tasks to migrate data alongside schema changes.}
   s.description = %q{Rake tasks to migrate data alongside schema changes.}
 
   s.rubyforge_project = "data_migrate"
 
-  s.add_dependency('rails', '>= 3.1.0')
+  s.add_dependency('rails', '>= 4.0')
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/data_migrate.gemspec
+++ b/data_migrate.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://ajvargo.com"
   s.summary     = %q{Rake tasks to migrate data alongside schema changes.}
   s.description = %q{Rake tasks to migrate data alongside schema changes.}
+  s.license     = "MIT"
 
   s.rubyforge_project = "data_migrate"
 

--- a/lib/data_migrate.rb
+++ b/lib/data_migrate.rb
@@ -1,2 +1,4 @@
 require File.join(File.dirname(__FILE__), 'data_migrate', 'data_migrator')
+require File.join(File.dirname(__FILE__), 'data_migrate', 'data_schema_migration')
+require File.join(File.dirname(__FILE__), 'data_migrate', 'migration')
 require File.join(File.dirname(__FILE__), 'data_migrate', 'railtie')

--- a/lib/data_migrate/data_migrator.rb
+++ b/lib/data_migrate/data_migrator.rb
@@ -1,8 +1,33 @@
 require 'active_record'
 
 module DataMigrate
+
   class DataMigrator < ActiveRecord::Migrator
+
+    def record_version_state_after_migrating(version)
+      if down?
+        migrated.delete(version)
+        DataMigrate::DataSchemaMigration.where(:version => version.to_s).delete_all
+      else
+        migrated << version
+        DataMigrate::DataSchemaMigration.create!(:version => version.to_s)
+      end
+    end
+
     class << self
+      def get_all_versions(connection = ActiveRecord::Base.connection)
+        if connection.table_exists?(schema_migrations_table_name)
+          # Certain versions of the gem wrote data migration versions into
+          # schema_migrations table. After the fix, it was corrected to write into
+          # data_migrations. However, not to break anything we are going to
+          # get versions from both tables
+          DataMigrate::DataSchemaMigration.all.map { |x| x.version.to_i }.sort +
+            ActiveRecord::SchemaMigration.all.map { |x| x.version.to_i }.sort
+        else
+          []
+        end
+      end
+
       def schema_migrations_table_name
         ActiveRecord::Base.table_name_prefix + 'data_migrations' + ActiveRecord::Base.table_name_suffix
       end

--- a/lib/data_migrate/data_migrator.rb
+++ b/lib/data_migrate/data_migrator.rb
@@ -20,7 +20,11 @@ module DataMigrate
           # Certain versions of the gem wrote data migration versions into
           # schema_migrations table. After the fix, it was corrected to write into
           # data_migrations. However, not to break anything we are going to
-          # get versions from both tables
+          # get versions from both tables.
+          #
+          # This may cause some problems:
+          # Eg. rake data:versions will show version from the schema_migrations table
+          # which may be a version of actual schema migration and not data migration
           DataMigrate::DataSchemaMigration.all.map { |x| x.version.to_i }.sort +
             ActiveRecord::SchemaMigration.all.map { |x| x.version.to_i }.sort
         else

--- a/lib/data_migrate/data_schema_migration.rb
+++ b/lib/data_migrate/data_schema_migration.rb
@@ -1,0 +1,14 @@
+module DataMigrate
+  class DataSchemaMigration < ::ActiveRecord::SchemaMigration
+    class << self
+      def table_name
+        ActiveRecord::Base.table_name_prefix + 'data_migrations' + ActiveRecord::Base.table_name_suffix
+      end
+
+      def index_name
+        "#{table_name_prefix}unique_data_migrations#{table_name_suffix}"
+      end
+    end
+  end
+end
+

--- a/lib/data_migrate/migration.rb
+++ b/lib/data_migrate/migration.rb
@@ -1,0 +1,28 @@
+module DataMigrate
+  class Migration < ::ActiveRecord::Migration
+
+    class << self
+      def check_pending!(connection = ::ActiveRecord::Base.connection)
+        binding.pry
+        raise ActiveRecord::PendingMigrationError if DataMigrator::Migrator.needs_migration?(connection)
+      end
+
+      def migrate(direction)
+        new.migrate direction
+      end
+
+      def table_name
+        binding.pry
+        ActiveRecord::Base.table_name_prefix + 'data_migrations' + ActiveRecord::Base.table_name_suffix
+      end
+
+      def index_name
+        "#{table_name_prefix}unique_data_migrations#{table_name_suffix}"
+      end
+    end
+
+    def initialize(name = self.class.name, version = nil)
+      super(name, version)
+    end
+  end
+end

--- a/lib/data_migrate/version.rb
+++ b/lib/data_migrate/version.rb
@@ -1,3 +1,3 @@
 module DataMigrate
-  VERSION = "1.2.0"
+  VERSION = "2.0.0"
 end

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -217,7 +217,7 @@ namespace :data do
   desc 'Migrate data migrations (options: VERSION=x, VERBOSE=false)'
   task :migrate => :environment do
     assure_data_schema_table
-    ActiveRecord::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
+    #ActiveRecord::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
     DataMigrate::DataMigrator.migrate("db/data/", ENV["VERSION"] ? ENV["VERSION"].to_i : nil)
   end
 


### PR DESCRIPTION
This PR will fix problem described in #22. This will entail creating a non-backward compatible version 2.0 since Rails 4.0 updated db migration code which conflicts with data_migrate