### PR TITLE
Add capistrano task for migrating with_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,20 @@ Going down instead of up would be the opposite.
 
 `rake db:migrate:status:with_data` provides and additional column to indicate which type of migration.
 
+Capistrano Support
+------------------
+
+The gem comes with a capistrano task that can be used instead of `capistrano/rails/migrations`.
+
+Just add this line to your Capfile:
+
+```ruby
+require 'capistrano/data_migrate'
+```
+
+From now on capistrano will run `rake db:migrate:with_data` in every deploy.
+
+
 Thanks
 ------
 [Andrew J Vargo](http://github.com/ajvargo) Andrew was the original creator and maintainer of this project!

--- a/lib/capistrano/data_migrate.rb
+++ b/lib/capistrano/data_migrate.rb
@@ -1,0 +1,3 @@
+require 'capistrano'
+
+require File.expand_path("#{File.dirname(__FILE__)}/data_migrate/migrate")

--- a/lib/capistrano/data_migrate/migrate.rb
+++ b/lib/capistrano/data_migrate/migrate.rb
@@ -1,0 +1,41 @@
+namespace :deploy do
+
+  desc 'Runs rake data:migrate if migrations are set'
+  task :migrate => [:set_rails_env] do
+    on fetch(:migration_servers) do
+      conditionally_migrate = fetch(:conditionally_migrate)
+      info '[deploy:migrate] Checking changes in db/migrate or db/data' if conditionally_migrate
+
+      if conditionally_migrate && (
+          test("diff -q #{release_path}/db/migrate #{current_path}/db/migrate") ||
+          test("diff -q #{release_path}/db/data #{current_path}/db/data")
+        )
+        info '[deploy:migrate] Skip `deploy:migrate` (nothing changed in db/migrate or db/data)'
+      else
+        info '[deploy:migrate] Run `rake db:migrate:with_data`'
+        invoke :'deploy:migrating_with_data'
+      end
+    end
+  end
+
+  desc 'Runs rake db:migrate:with_data'
+  task migrating_with_data: [:set_rails_env] do
+    on fetch(:migration_servers) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :rake, 'db:migrate:with_data'
+        end
+      end
+    end
+  end
+
+  after 'deploy:updated', 'deploy:migrate'
+end
+
+namespace :load do
+  task :defaults do
+    set :conditionally_migrate, fetch(:conditionally_migrate, false)
+    set :migration_role, fetch(:migration_role, :db)
+    set :migration_servers, -> { primary(fetch(:migration_role)) }
+  end
+end


### PR DESCRIPTION
This task will override default deploy:migrate task
from `capistrano/rails`