### PR TITLE
To override capistrano 3 task we need to clear previous task first

### DIFF
--- a/lib/capistrano/data_migrate/migrate.rb
+++ b/lib/capistrano/data_migrate/migrate.rb
@@ -1,6 +1,7 @@
 namespace :deploy do
 
   desc 'Runs rake data:migrate if migrations are set'
+  Rake::Task['deploy:migrate'].clear_actions
   task :migrate => [:set_rails_env] do
     on fetch(:migration_servers) do
       conditionally_migrate = fetch(:conditionally_migrate)


### PR DESCRIPTION
When I first deployed I got this capistrano output which indicates that it's calling capistrano-rails task and only then data-migrate capistrano task. So as capistrano 3 docs says http://capistranorb.com/documentation/advanced-features/overriding-capistrano-tasks we need to clear previous tasks first.

```
00:27 deploy:migrate
      [deploy:migrate] Checking changes in /db/migrate
      [deploy:migrate] Run `rake db:migrate`
00:27 deploy:migrating
      [deploy:migrate] Checking changes in db/migrate or db/data
      [deploy:migrate] Run `rake db:migrate:with_data`

```
and after only data-migrate

```
00:23 deploy:migrate
      [deploy:migrate] Checking changes in db/migrate or db/data
      [deploy:migrate] Skip `deploy:migrate` (nothing changed in db/migrate or db/data)
```