### PR TITLE
fix: rake generate data_migration fails when migrations are not timestamped

### DIFF
--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -19,12 +19,9 @@ module DataMigrate
 
       attr_reader :migration_action
 
-      def self.next_migration_number(dirname)
-        if ActiveRecord::Base.timestamped_migrations
-          Time.new.utc.strftime("%Y%m%d%H%M%S")
-        else
-          "%.3d" % (current_migration_number(dirname) + 1)
-        end
+      def next_migration_number(dirname)
+        next_migration_number = current_migration_number(dirname) + 1
+        ActiveRecord::Migration.next_migration_number(next_migration_number)
       end
 
       def set_local_assigns!


### PR DESCRIPTION
…tamped

ActiveRecord::Base.timestamped_migrations has been deprecated