### PR TITLE
Fix Rails 5 deprecation warnings

### DIFF
--- a/Gemfile.rails5
+++ b/Gemfile.rails5
@@ -2,4 +2,4 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in data_migrate.gemspec
 gemspec
-gem 'rails', '>=5.0.0'
+gem 'rails', '~> 5.0.0'

--- a/data_migrate.gemspec
+++ b/data_migrate.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "data_migrate"
 
-  s.add_dependency('rails', '>= 4.0')
+  s.add_dependency('rails', '>= 4.0', '< 5.1')
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rspec-core"

--- a/lib/data_migrate/data_migrator.rb
+++ b/lib/data_migrate/data_migrator.rb
@@ -16,7 +16,7 @@ module DataMigrate
 
     class << self
       def get_all_versions(connection = ActiveRecord::Base.connection)
-        if connection.table_exists?(schema_migrations_table_name)
+        if table_exists?(connection, schema_migrations_table_name)
           # Certain versions of the gem wrote data migration versions into
           # schema_migrations table. After the fix, it was corrected to write into
           # data_migrations. However, not to break anything we are going to
@@ -45,7 +45,7 @@ module DataMigrate
         ActiveRecord::Base.establish_connection(config)
         sm_table = DataMigrate::DataMigrator.schema_migrations_table_name
 
-        unless ActiveRecord::Base.connection.table_exists?(sm_table)
+        unless table_exists?(ActiveRecord::Base.connection, sm_table)
           ActiveRecord::Base.connection.create_table(sm_table, :id => false) do |schema_migrations_table|
             schema_migrations_table.column :version, :string, :null => false
           end
@@ -60,6 +60,17 @@ module DataMigrate
         end
       end
 
+      private
+
+      def table_exists?(connection, table_name)
+        # Avoid the warning that table_exists? prints in Rails 5.0 due a change in behavior between
+        # Rails 5.0 and Rails 5.1 of this method with respect to database views.
+        if ActiveRecord.version >= Gem::Version.new('5.0') && ActiveRecord.version < Gem::Version.new('5.1')
+          connection.data_source_exists?(table_name)
+        else
+          connection.table_exists?(schema_migrations_table_name)
+        end
+      end
     end
   end
 end

--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -33,6 +33,14 @@ module DataMigrate
           @table_name       = $2.pluralize
         end
       end
+
+      def migration_base_class_name
+        if ActiveRecord.version >= Gem::Version.new('5.0')
+          "ActiveRecord::Migration[#{ActiveRecord::Migration.current_version}]"
+        else
+          'ActiveRecord::Migration'
+        end
+      end
     end
   end
 end

--- a/lib/generators/data_migration/templates/data_migration.rb
+++ b/lib/generators/data_migration/templates/data_migration.rb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < <%= migration_base_class_name %>
   def self.up
   end
 

--- a/spec/generators/data_migration/data_migration_generator_spec.rb
+++ b/spec/generators/data_migration/data_migration_generator_spec.rb
@@ -13,4 +13,15 @@ describe DataMigrate::Generators::DataMigrationGenerator do
       end
     end
   end
+
+  describe :migration_base_class_name do
+    let(:subject) { DataMigrate::Generators::DataMigrationGenerator.new(['my_migration']) }
+    it "returns the correct base class name" do
+      if ActiveRecord.version >= Gem::Version.new('5.0')
+        expect(subject.send(:migration_base_class_name)).to eq("ActiveRecord::Migration[#{ActiveRecord::Migration.current_version}]")
+      else
+        expect(subject.send(:migration_base_class_name)).to eq('ActiveRecord::Migration')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes two deprecation warnings in Rails 5.0:

1) The base class for migrations should be versioned for Rails 5.0+ e.g. `ActiveRecord::Migration[5.0]`. See the Rails [migration template](https://github.com/rails/rails/blob/5-0-stable/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb) for more tails.
2) `ConnectionAdapter#table_exists?` changed behavior between Rails 5.0 and Rails 5.1 to exclude views. This results in a deprecation warning only when called from Rails 5.0 (i.e. not Rails 5.1). See https://github.com/rails/rails/commit/7429633b824cf8aaeea52d11876e7bd2b8d2f256 and https://github.com/rails/rails/commit/5973a984c369a63720c2ac18b71012b8347479a8 for more details.

This will also fix the tests failures caused when running against Rails 5.1 (see https://travis-ci.org/ilyakatz/data-migrate/builds/235395561). As a sidenote, I'd be happy to put a PR to run Travis builds against both Rails 5.0 and 5.1 if you're interested.