### PR TITLE
Directly inheriting from ActiveRecord::Migration is not supported in Rails 5.1

### DIFF
--- a/lib/data_migrate.rb
+++ b/lib/data_migrate.rb
@@ -1,4 +1,8 @@
 require File.join(File.dirname(__FILE__), 'data_migrate', 'data_migrator')
 require File.join(File.dirname(__FILE__), 'data_migrate', 'data_schema_migration')
-require File.join(File.dirname(__FILE__), 'data_migrate', 'migration')
+if Rails::VERSION::MAJOR >= 5
+  require File.join(File.dirname(__FILE__), 'data_migrate', 'migration_five')
+else
+  require File.join(File.dirname(__FILE__), 'data_migrate', 'migration')
+end
 require File.join(File.dirname(__FILE__), 'data_migrate', 'railtie')

--- a/lib/data_migrate/migration.rb
+++ b/lib/data_migrate/migration.rb
@@ -1,5 +1,5 @@
 module DataMigrate
-  class Migration < ::ActiveRecord::Migration
+  class Migration < ::ActiveRecord::Migration[5.0]
 
     class << self
       def check_pending!(connection = ::ActiveRecord::Base.connection)

--- a/lib/data_migrate/migration.rb
+++ b/lib/data_migrate/migration.rb
@@ -1,5 +1,5 @@
 module DataMigrate
-  class Migration < ::ActiveRecord::Migration[5.0]
+  class Migration < ::ActiveRecord::Migration[4.2]
 
     class << self
       def check_pending!(connection = ::ActiveRecord::Base.connection)

--- a/lib/data_migrate/migration_five.rb
+++ b/lib/data_migrate/migration_five.rb
@@ -1,5 +1,5 @@
 module DataMigrate
-  class Migration < ::ActiveRecord::Migration
+  class MigrationFive < ::ActiveRecord::Migration[5.0]
 
     class << self
       def check_pending!(connection = ::ActiveRecord::Base.connection)


### PR DESCRIPTION
More info here:
https://github.com/ilyakatz/data-migrate/issues/53
https://github.com/RolifyCommunity/rolify/issues/444