### PR TITLE
Make schema dumping consistent with ActiveRecord migrations tasks

### DIFF
--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -57,7 +57,7 @@ namespace :db do
         end
       end
 
-      Rake::Task["db:schema:dump"].invoke if ActiveRecord::Base.schema_format == :ruby
+      Rake::Task["db:_dump"].invoke
     end
 
     namespace :redo do
@@ -96,6 +96,8 @@ namespace :db do
             ActiveRecord::Migrator.run(:up, "db/migrate/", migration[:version])
           end
         end
+
+        Rake::Task["db:_dump"].invoke
       end
     end
 
@@ -121,6 +123,8 @@ namespace :db do
             ActiveRecord::Migrator.run(:down, "db/migrate/", migration[:version])
           end
         end
+
+        Rake::Task["db:_dump"].invoke
       end
     end
 
@@ -184,6 +188,8 @@ namespace :db do
           ActiveRecord::Migrator.run(:down, "db/migrate/", past_migration[:version])
         end
       end
+
+      Rake::Task["db:_dump"].invoke
     end
   end
 
@@ -204,6 +210,8 @@ namespace :db do
           ActiveRecord::Migrator.run(:up, "db/migrate/", pending_migration[:version])
         end
       end
+
+      Rake::Task["db:_dump"].invoke
     end
   end
 


### PR DESCRIPTION
This PR updates the [schema dumping](http://guides.rubyonrails.org/v5.0.0/active_record_migrations.html#schema-dumping-and-you) of the various `db:*:with_data` Rake tasks to be consistent with their non-with_data counterparts. In particular it now handles:

* Schema dumps in `:sql` or `:ruby` format. 
* Dumping the schema after running the `db:migrate:with_data`, `db:migrate:up:with_data`, `db:migrate:down:with_data`, `db:rollback:with_data` and `db:forward:with_data` tasks.
* Honoring the ActiveRecord::Base.dump_schema_after_migration setting (Rails 4.2 and above)

Implementation-wise this just leverages the [db:_dump](https://github.com/rails/rails/blob/5-0-stable/activerecord/lib/active_record/railties/databases.rake#L63) task that was introduced in Rails 3.2.
