### PR TITLE
Resolves #77 by always using the ruby format for the data schema

### DIFF
--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -2,19 +2,12 @@
 
 module DataMigrate
   ##
-  # This class extends DatabaseTasks to override the schema_file method.
+  # This class extends DatabaseTasks to add a data_schema_file method.
   class DatabaseTasks
     extend ActiveRecord::Tasks::DatabaseTasks
 
-    def self.schema_file(format = ActiveRecord::Base.schema_format)
-      case format
-      when :ruby
-        File.join(db_dir, "data_schema.rb")
-      else
-        message = "Only Ruby-based data_schema files are supported " \
-          "at this time."
-        Kernel.abort message
-      end
+    def self.data_schema_file
+      File.join(db_dir, "data_schema.rb")
     end
   end
 end

--- a/spec/data_migrate/database_tasks_spec.rb
+++ b/spec/data_migrate/database_tasks_spec.rb
@@ -10,9 +10,9 @@ describe DataMigrate::DatabaseTasks do
     allow(subject).to receive(:db_dir).and_return("db")
   end
 
-  describe :schema_file do
+  describe :data_schema_file do
     it "returns the correct data schema file path" do
-      expect(subject.schema_file).to eq "db/data_schema.rb"
+      expect(subject.data_schema_file).to eq "db/data_schema.rb"
     end
   end
 end

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -343,17 +343,9 @@ namespace :data do
   desc "Create a db/data_schema.rb file that stores the current data version"
   task dump: :environment do
     if ActiveRecord::Base.dump_schema_after_migration
-      case ActiveRecord::Base.schema_format
-      when :ruby
-        filename = DataMigrate::DatabaseTasks.schema_file
-        File.open(filename, "w:utf-8") do |file|
-          DataMigrate::SchemaDumper.dump(ActiveRecord::Base.connection, file)
-        end
-      else
-        raise <<-MSG.strip_heredoc
-          only Ruby-based data_schema files are supported at this time
-          (unknown schema format #{ActiveRecord::Base.schema_format})
-        MSG
+      filename = DataMigrate::DatabaseTasks.data_schema_file
+      File.open(filename, "w:utf-8") do |file|
+        DataMigrate::SchemaDumper.dump(ActiveRecord::Base.connection, file)
       end
     end
 


### PR DESCRIPTION
This PR eliminates the check for the schema format. It now uses a ruby format regardless of the preferred format for the rails schema file.

I considered changing the file name from `data_schema.rb` to `data_version.rb`. The file doesn't actually describe a schema, just an assumed version of the data. It seemed best to hold off on that to avoid breaking compatibility with anyone who has already installed v.3.3.0.