### PR TITLE
Fix db:schema:load:with_data by reverting #78

### DIFF
--- a/lib/data_migrate/data_migrator_five.rb
+++ b/lib/data_migrate/data_migrator_five.rb
@@ -6,6 +6,14 @@ module DataMigrate
   class DataMigrator < ActiveRecord::Migrator
     self.migrations_paths = ["db/data"]
 
+    def self.migrations_path
+      "db/data"
+    end
+
+    def self.full_migrations_path
+      File.join(Rails.root, *migrations_path.split(File::SEPARATOR))
+    end
+
     def self.assure_data_schema_table
       DataMigrate::DataSchemaMigration.create_table
     end

--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -2,12 +2,19 @@
 
 module DataMigrate
   ##
-  # This class extends DatabaseTasks to add a data_schema_file method.
+  # This class extends DatabaseTasks to override the schema_file method.
   class DatabaseTasks
     extend ActiveRecord::Tasks::DatabaseTasks
 
-    def self.data_schema_file
-      File.join(db_dir, "data_schema.rb")
+    def self.schema_file(format = ActiveRecord::Base.schema_format)
+      case format
+      when :ruby
+        File.join(db_dir, "data_schema.rb")
+      else
+        message = "Only Ruby-based data_schema files are supported " \
+          "at this time."
+        Kernel.abort message
+      end
     end
 
     def self.forward(step = 1)

--- a/spec/data_migrate/database_tasks_spec.rb
+++ b/spec/data_migrate/database_tasks_spec.rb
@@ -40,17 +40,9 @@ describe DataMigrate::DatabaseTasks do
     allow(subject).to receive(:db_dir).and_return("db")
   end
 
-  before do
-    allow(DataMigrate::Tasks::DataMigrateTasks).to receive(:migrations_paths) {
-      data_migrations_path
-    }
-    allow(DataMigrate::DataMigrator).to receive(:db_config) { db_config }
-    ActiveRecord::Base.establish_connection(db_config)
-  end
-
-  describe :data_schema_file do
+  describe :schema_file do
     it "returns the correct data schema file path" do
-      expect(subject.data_schema_file).to eq "db/data_schema.rb"
+      expect(subject.schema_file).to eq "db/data_schema.rb"
     end
   end
 

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -313,9 +313,17 @@ namespace :data do
   desc "Create a db/data_schema.rb file that stores the current data version"
   task dump: :environment do
     if ActiveRecord::Base.dump_schema_after_migration
-      filename = DataMigrate::DatabaseTasks.data_schema_file
-      File.open(filename, "w:utf-8") do |file|
-        DataMigrate::SchemaDumper.dump(ActiveRecord::Base.connection, file)
+      case ActiveRecord::Base.schema_format
+      when :ruby
+        filename = DataMigrate::DatabaseTasks.schema_file
+        File.open(filename, "w:utf-8") do |file|
+          DataMigrate::SchemaDumper.dump(ActiveRecord::Base.connection, file)
+        end
+      else
+        raise <<-MSG.strip_heredoc
+          only Ruby-based data_schema files are supported at this time
+          (unknown schema format #{ActiveRecord::Base.schema_format})
+        MSG
       end
     end
 


### PR DESCRIPTION
All this does is revert 3987603 (#78) and add the missing methods to DataMigrator (`.migrations_path`, `.full_migrations_path`). I don't think this is the optimal fix, but it's definitely working again. 