### PR TITLE
Fix library for MySQL database with utf8mb4 encoding

### DIFF
--- a/lib/data_migrate/data_migrator.rb
+++ b/lib/data_migrate/data_migrator.rb
@@ -86,7 +86,8 @@ module DataMigrate
 
           ActiveRecord::Base.connection.add_index sm_table, :version,
             :unique => true,
-            :name => index_name
+            :name => index_name,
+            :length => 191
       end
 
       def table_exists?(connection, table_name)

--- a/lib/data_migrate/data_migrator.rb
+++ b/lib/data_migrate/data_migrator.rb
@@ -83,11 +83,11 @@ module DataMigrate
           suffix = ActiveRecord::Base.table_name_suffix
           prefix = ActiveRecord::Base.table_name_prefix
           index_name = "#{prefix}unique_data_migrations#{suffix}"
+          
+          options = {unique: true, name: index_name}          
+          options[:length] = 191 if ActiveRecord::Base.connection_config[:adapter] == "mysql2"
 
-          ActiveRecord::Base.connection.add_index sm_table, :version,
-            :unique => true,
-            :name => index_name,
-            :length => 191
+          ActiveRecord::Base.connection.add_index sm_table, :version, options
       end
 
       def table_exists?(connection, table_name)

--- a/lib/data_migrate/data_migrator.rb
+++ b/lib/data_migrate/data_migrator.rb
@@ -3,16 +3,15 @@
 require "active_record"
 
 module DataMigrate
-
   class DataMigrator < ActiveRecord::Migrator
 
     def record_version_state_after_migrating(version)
       if down?
         migrated.delete(version)
-        DataMigrate::DataSchemaMigration.where(:version => version.to_s).delete_all
+        DataMigrate::DataSchemaMigration.where(version: version.to_s).delete_all
       else
         migrated << version
-        DataMigrate::DataSchemaMigration.create!(:version => version.to_s)
+        DataMigrate::DataSchemaMigration.create!(version: version.to_s)
       end
     end
 
@@ -76,8 +75,8 @@ module DataMigrate
       private
 
       def create_table(sm_table)
-        ActiveRecord::Base.connection.create_table(sm_table, :id => false) do |schema_migrations_table|
-          schema_migrations_table.column :version, :string, :null => false
+        ActiveRecord::Base.connection.create_table(sm_table, id: false) do |schema_migrations_table|
+          schema_migrations_table.column :version, :string, null: false
         end
 
         suffix = ActiveRecord::Base.table_name_suffix

--- a/lib/data_migrate/data_migrator.rb
+++ b/lib/data_migrate/data_migrator.rb
@@ -77,17 +77,17 @@ module DataMigrate
 
       def create_table(sm_table)
         ActiveRecord::Base.connection.create_table(sm_table, :id => false) do |schema_migrations_table|
-            schema_migrations_table.column :version, :string, :null => false
-          end
+          schema_migrations_table.column :version, :string, :null => false
+        end
 
-          suffix = ActiveRecord::Base.table_name_suffix
-          prefix = ActiveRecord::Base.table_name_prefix
-          index_name = "#{prefix}unique_data_migrations#{suffix}"
-          
-          options = {unique: true, name: index_name}          
-          options[:length] = 191 if ActiveRecord::Base.connection_config[:adapter] == "mysql2"
+        suffix = ActiveRecord::Base.table_name_suffix
+        prefix = ActiveRecord::Base.table_name_prefix
+        index_name = "#{prefix}unique_data_migrations#{suffix}"
 
-          ActiveRecord::Base.connection.add_index sm_table, :version, options
+        options = {unique: true, name: index_name}
+        options[:length] = 191 if ActiveRecord::Base.connection_config[:adapter] == "mysql2"
+
+        ActiveRecord::Base.connection.add_index sm_table, :version, options
       end
 
       def table_exists?(connection, table_name)


### PR DESCRIPTION
If your MySQL database is using full Unicode encoding (utf8mb4) then index can be of maximum length of 191 (because MySQL supports only 767 bytes as index length and one char is 4 bytes). That's why all indexes have to be of maximum length of 191.

This PR fixes that - however it'd be adding this length to every database. But I didn't know how to check encoding and add it conditionally.