### PR TITLE
Fix use relative db/data path

### DIFF
--- a/lib/data_migrate.rb
+++ b/lib/data_migrate.rb
@@ -39,7 +39,7 @@ module DataMigrate
     end
 
     def data_migrations_paths
-      @data_migrations_paths ||= Rails.application.paths["data/migrate"]&.existent || [ File.join(Rails.root, "data/data") ]
+      @data_migrations_paths ||= Rails.application.paths["data/migrate"]&.existent || [ File.join(Rails.root, "data/migrate") ]
     end
 
     def db_migrations_paths

--- a/lib/data_migrate.rb
+++ b/lib/data_migrate.rb
@@ -38,12 +38,12 @@ module DataMigrate
       yield config
     end
 
-    def data_migrations_path
-      @data_migrations_path ||= Rails.application.paths["db/data"].existent || File.join(Rails.root, "db/data")
+    def data_migrations_paths
+      @data_migrations_paths ||= Rails.application.paths["data/migrate"]&.existent || [ File.join(Rails.root, "data/data") ]
     end
 
-    def db_migrations_path
-      @db_migrations_path ||= Rails.application.paths["db/migrate"].existent || File.join(Rails.root, "db/migrate")
+    def db_migrations_paths
+      @db_migrations_paths ||= Rails.application.paths["db/migrate"].existent || [ File.join(Rails.root, "db/migrate") ]
     end
   end
 end

--- a/lib/data_migrate.rb
+++ b/lib/data_migrate.rb
@@ -32,9 +32,18 @@ require File.join(File.dirname(__FILE__), "data_migrate", "legacy_migrator")
 
 module DataMigrate
   include ActiveSupport::Configurable
+
   class << self
     def configure
       yield config
+    end
+
+    def data_migrations_path
+      @data_migrations_path ||= Rails.application.paths["db/data"].existent || File.join(Rails.root, "db/data")
+    end
+
+    def db_migrations_path
+      @db_migrations_path ||= Rails.application.paths["db/migrate"].existent || File.join(Rails.root, "db/migrate")
     end
   end
 end

--- a/lib/data_migrate/data_migrator.rb
+++ b/lib/data_migrate/data_migrator.rb
@@ -38,15 +38,11 @@ module DataMigrate
           ActiveRecord::Base.table_name_suffix
       end
 
-      def migrations_path
-        "db/data"
-      end
-
       ##
       # Provides the full migrations_path filepath
       # @return (String)
       def full_migrations_path
-        File.join(Rails.root, *migrations_path.split(File::SEPARATOR))
+        DataMigrate.data_migrations_path.first
       end
 
       def assure_data_schema_table

--- a/lib/data_migrate/data_migrator.rb
+++ b/lib/data_migrate/data_migrator.rb
@@ -42,7 +42,7 @@ module DataMigrate
       # Provides the full migrations_path filepath
       # @return (String)
       def full_migrations_path
-        DataMigrate.data_migrations_path.first
+        DataMigrate.data_migrations_paths.first
       end
 
       def assure_data_schema_table

--- a/lib/data_migrate/data_migrator_five.rb
+++ b/lib/data_migrate/data_migrator_five.rb
@@ -46,7 +46,7 @@ module DataMigrate
       # Provides the full migrations_path filepath
       # @return (String)
       def full_migrations_path
-        File.join(Rails.root, *migrations_paths.split(File::SEPARATOR))
+        DataMigrate.data_migrations_path.first
       end
 
       def migrations_status

--- a/lib/data_migrate/data_migrator_five.rb
+++ b/lib/data_migrate/data_migrator_five.rb
@@ -46,7 +46,7 @@ module DataMigrate
       # Provides the full migrations_path filepath
       # @return (String)
       def full_migrations_path
-        DataMigrate.data_migrations_path.first
+        DataMigrate.data_migrations_paths.first
       end
 
       def migrations_status

--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -26,11 +26,12 @@ module DataMigrate
     end
 
     def self.data_migrations_path
-      "db/data/"
+      DataMigrate.data_migrations_path.first
+
     end
 
     def self.schema_migrations_path
-      "db/migrate/"
+      DataMigrate.db_migrations_path.first
     end
 
     def self.pending_migrations

--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -26,12 +26,12 @@ module DataMigrate
     end
 
     def self.data_migrations_path
-      DataMigrate.data_migrations_path.first
+      DataMigrate.data_migrations_paths.first
 
     end
 
     def self.schema_migrations_path
-      DataMigrate.db_migrations_path.first
+      DataMigrate.db_migrations_paths.first
     end
 
     def self.pending_migrations

--- a/lib/data_migrate/migration_context.rb
+++ b/lib/data_migrate/migration_context.rb
@@ -1,7 +1,7 @@
 module DataMigrate
   class MigrationContext < ActiveRecord::MigrationContext
     def initialize(migrations_paths = "db/data")
-      @migrations_paths = migrations_paths || "db/data"
+      @migrations_paths = migrations_paths
     end
 
     def up(target_version = nil)

--- a/lib/data_migrate/schema_migration.rb
+++ b/lib/data_migrate/schema_migration.rb
@@ -21,7 +21,7 @@ module DataMigrate
     end
 
     def self.migrations_paths
-      Rails.application.config.paths["db/migrate"].to_a
+      DataMigrate.db_migrations_paths
     end
 
     def self.sort_string(migration)

--- a/lib/data_migrate/schema_migration_five.rb
+++ b/lib/data_migrate/schema_migration_five.rb
@@ -21,7 +21,7 @@ module DataMigrate
     end
 
     def self.migrations_paths
-      Rails.application.config.paths["db/migrate"].to_a
+      DataMigrate.db_migrations_paths
     end
 
     def self.sort_string(migration)

--- a/lib/data_migrate/status_service.rb
+++ b/lib/data_migrate/status_service.rb
@@ -52,7 +52,8 @@ module DataMigrate
 
     def migration_files(db_list)
       file_list = []
-      Dir.foreach(File.join(root_folder, "db", "data")) do |file|
+      binding.pry
+      Dir.foreach(DataMigrate.data_migrations_path.first) do |file|
         # only files matching "20091231235959_some_name.rb" pattern
         if match_data = DataMigrate::DataMigrator.match(file)
           status = db_list.delete(match_data[1]) ? "up" : "down"

--- a/lib/data_migrate/status_service.rb
+++ b/lib/data_migrate/status_service.rb
@@ -52,7 +52,6 @@ module DataMigrate
 
     def migration_files(db_list)
       file_list = []
-      binding.pry
       Dir.foreach(DataMigrate.data_migrations_path.first) do |file|
         # only files matching "20091231235959_some_name.rb" pattern
         if match_data = DataMigrate::DataMigrator.match(file)

--- a/lib/data_migrate/status_service.rb
+++ b/lib/data_migrate/status_service.rb
@@ -52,7 +52,7 @@ module DataMigrate
 
     def migration_files(db_list)
       file_list = []
-      Dir.foreach(DataMigrate.data_migrations_path.first) do |file|
+      Dir.foreach(DataMigrate.data_migrations_paths.first) do |file|
         # only files matching "20091231235959_some_name.rb" pattern
         if match_data = DataMigrate::DataMigrator.match(file)
           status = db_list.delete(match_data[1]) ? "up" : "down"

--- a/lib/data_migrate/tasks/data_migrate_tasks.rb
+++ b/lib/data_migrate/tasks/data_migrate_tasks.rb
@@ -3,13 +3,7 @@ module DataMigrate
     module DataMigrateTasks
       extend self
       def migrations_paths
-        @migrations_paths ||= begin
-          if Rails.application && Rails.application.paths["db/data"]
-            Rails.application.paths["db/data"].to_a
-          else
-            "db/data/"
-          end
-        end
+        DataMigrate.data_migrations_paths
       end
 
       def migrate

--- a/lib/data_migrate/tasks/data_migrate_tasks.rb
+++ b/lib/data_migrate/tasks/data_migrate_tasks.rb
@@ -4,8 +4,10 @@ module DataMigrate
       extend self
       def migrations_paths
         @migrations_paths ||= begin
-          if Rails.application && Rails.application.paths["data/migrate"]
-            Rails.application.paths["data/migrate"].to_a
+          if Rails.application && Rails.application.paths["db/data"]
+            Rails.application.paths["db/data"].to_a
+          else
+            "db/data/"
           end
         end
       end
@@ -16,7 +18,7 @@ module DataMigrate
         if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR == 2
           DataMigrate::MigrationContext.new(migrations_paths).migrate(target_version)
         else
-          paths = migrations_paths || "db/data/"
+          paths = migrations_paths
           DataMigrate::DataMigrator.migrate(paths, ENV["VERSION"] ? ENV["VERSION"].to_i : nil)
         end
       end

--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -13,7 +13,7 @@ module DataMigrate
 
       def create_data_migration
         set_local_assigns!
-        migration_template "data_migration.rb", "db/data/#{file_name}.rb"
+        migration_template "data_migration.rb", DataMigrate.data_migrations_path + "/#{file_name}.rb"
       end
 
       protected

--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -13,7 +13,7 @@ module DataMigrate
 
       def create_data_migration
         set_local_assigns!
-        migration_template "data_migration.rb", DataMigrate.data_migrations_path.first + "/#{file_name}.rb"
+        migration_template "data_migration.rb", DataMigrate.data_migrations_paths.first + "/#{file_name}.rb"
       end
 
       protected

--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -13,7 +13,7 @@ module DataMigrate
 
       def create_data_migration
         set_local_assigns!
-        migration_template "data_migration.rb", DataMigrate.data_migrations_path + "/#{file_name}.rb"
+        migration_template "data_migration.rb", DataMigrate.data_migrations_path.first + "/#{file_name}.rb"
       end
 
       protected

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -389,3 +389,19 @@ end
 def assure_data_schema_table
   DataMigrate::DataMigrator.assure_data_schema_table
 end
+
+def db_data_path
+  if Rails.application && Rails.application.paths["db/data"]
+    Rails.application.paths["db/data"].existent.first
+  else
+    File.join(Rails.root, "db", "data")
+  end
+end
+
+def db_migrate_path
+  if Rails.application && Rails.application.paths["db/migrate"]
+    Rails.application.paths["db/migrate"].existent.first
+  else
+    File.join(Rails.root, "db", "migrate")
+  end
+end

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -254,7 +254,6 @@ end
 namespace :data do
   desc 'Migrate data migrations (options: VERSION=x, VERBOSE=false)'
   task :migrate => :environment do
-    binding.pry
     DataMigrate::Tasks::DataMigrateTasks.migrate
     Rake::Task["data:dump"].invoke
   end

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -48,7 +48,7 @@ namespace :db do
       migrations.each do |migration|
         if migration[:kind] == :data
           ActiveRecord::Migration.write("== %s %s" % ['Data', "=" * 71])
-          DataMigrate::DataMigrator.run(migration[:direction], DataMigrate.data_migrations_path, migration[:version])
+          DataMigrate::DataMigrator.run(migration[:direction], DataMigrate.data_migrations_paths, migration[:version])
         else
           ActiveRecord::Migration.write("== %s %s" % ['Schema', "=" * 69])
           DataMigrate::SchemaMigration.run(
@@ -93,10 +93,10 @@ namespace :db do
         migrations.each do |migration|
           if migration[:kind] == :data
             ActiveRecord::Migration.write("== %s %s" % ['Data', "=" * 71])
-            DataMigrate::DataMigrator.run(:up, DataMigrate.data_migrations_path, migration[:version])
+            DataMigrate::DataMigrator.run(:up, DataMigrate.data_migrations_paths, migration[:version])
           else
             ActiveRecord::Migration.write("== %s %s" % ['Schema', "=" * 69])
-            DataMigrate::SchemaMigration.run(:up, DataMigrate.db_migrations_path, migration[:version])
+            DataMigrate::SchemaMigration.run(:up, DataMigrate.db_migrations_paths, migration[:version])
           end
         end
 
@@ -121,10 +121,10 @@ namespace :db do
         migrations.each do |migration|
           if migration[:kind] == :data
             ActiveRecord::Migration.write("== %s %s" % ['Data', "=" * 71])
-            DataMigrate::DataMigrator.run(:down, DataMigrate.data_migrations_path, migration[:version])
+            DataMigrate::DataMigrator.run(:down, DataMigrate.data_migrations_paths, migration[:version])
           else
             ActiveRecord::Migration.write("== %s %s" % ['Schema', "=" * 69])
-            DataMigrate::SchemaMigration.run(:down, DataMigrate.db_migrations_path, migration[:version])
+            DataMigrate::SchemaMigration.run(:down, DataMigrate.db_migrations_paths, migration[:version])
           end
         end
 
@@ -146,7 +146,7 @@ namespace :db do
           "SELECT version FROM #{ActiveRecord::SchemaMigration.schema_migrations_table_name}"
         )
         file_list = []
-        Dir.foreach(DataMigrate.data_migrations_path.first) do |file|
+        Dir.foreach(DataMigrate.data_migrations_paths.first) do |file|
           # only files matching "20091231235959_some_name.rb" pattern
           if match_data = /(\d{14})_(.+)\.rb/.match(file)
             status = db_list_data.delete(match_data[1]) ? 'up' : 'down'
@@ -154,7 +154,7 @@ namespace :db do
           end
         end
 
-        Dir.foreach(DataMigrate.db_migrations_path.first) do |file|
+        Dir.foreach(DataMigrate.db_migrations_paths.first) do |file|
           # only files matching "20091231235959_some_name.rb" pattern
           if match_data = /(\d{14})_(.+)\.rb/.match(file)
             status = db_list_schema.delete(match_data[1]) ? 'up' : 'down'
@@ -190,10 +190,10 @@ namespace :db do
       past_migrations[0..(step - 1)].each do | past_migration |
         if past_migration[:kind] == :data
           ActiveRecord::Migration.write("== %s %s" % ['Data', "=" * 71])
-          DataMigrate::DataMigrator.run(:down, DataMigrate.data_migrations_path, past_migration[:version])
+          DataMigrate::DataMigrator.run(:down, DataMigrate.data_migrations_paths, past_migration[:version])
         elsif past_migration[:kind] == :schema
           ActiveRecord::Migration.write("== %s %s" % ['Schema', "=" * 69])
-          ActiveRecord::Migrator.run(:down, DataMigrate.db_migrations_path, past_migration[:version])
+          ActiveRecord::Migrator.run(:down, DataMigrate.db_migrations_paths, past_migration[:version])
         end
       end
 
@@ -276,7 +276,7 @@ namespace :data do
       assure_data_schema_table
       version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
       raise "VERSION is required" unless version
-      DataMigrate::DataMigrator.run(:up, DataMigrate.data_migrations_path, version)
+      DataMigrate::DataMigrator.run(:up, DataMigrate.data_migrations_paths, version)
       Rake::Task["data:dump"].invoke
     end
 
@@ -285,7 +285,7 @@ namespace :data do
       version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
       raise "VERSION is required" unless version
       assure_data_schema_table
-      DataMigrate::DataMigrator.run(:down, DataMigrate.data_migrations_path, version)
+      DataMigrate::DataMigrator.run(:down, DataMigrate.data_migrations_paths, version)
       Rake::Task["data:dump"].invoke
     end
 
@@ -304,7 +304,7 @@ namespace :data do
   task :rollback => :environment do
     assure_data_schema_table
     step = ENV['STEP'] ? ENV['STEP'].to_i : 1
-      DataMigrate::DataMigrator.rollback(DataMigrate.data_migrations_path, step)
+      DataMigrate::DataMigrator.rollback(DataMigrate.data_migrations_paths, step)
     Rake::Task["data:dump"].invoke
   end
 
@@ -316,7 +316,7 @@ namespace :data do
     # DataMigrate::DataMigrator.forward('db/data/', step)
     migrations = pending_data_migrations.reverse.pop(step).reverse
     migrations.each do | pending_migration |
-      DataMigrate::DataMigrator.run(:up, DataMigrate.data_migrations_path, pending_migration[:version])
+      DataMigrate::DataMigrator.run(:up, DataMigrate.data_migrations_paths, pending_migration[:version])
     end
     Rake::Task["data:dump"].invoke
   end

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -304,7 +304,7 @@ namespace :data do
   task :rollback => :environment do
     assure_data_schema_table
     step = ENV['STEP'] ? ENV['STEP'].to_i : 1
-    DataMigrate::DataMigrator.rollback('db/data/', step)
+    DataMigrate::DataMigrator.rollback(DataMigrate::Tasks::DataMigrateTasks.migrations_paths, step)
     Rake::Task["data:dump"].invoke
   end
 


### PR DESCRIPTION
Hi there!

I have a quite specific case. I've got defined migrations in the other project than I want to execute them.
Therefore, there's a problem with paths to the migrations, because they are searched in `first_project/db/data` while they are placed in `second_project/db/data`.
I decided to improve it.

I followed this example: https://github.com/ilyakatz/data-migrate/blob/master/lib/data_migrate/tasks/data_migrate_tasks.rb#L5
and use relative paths in some rake tasks.

However, there are many places where such relative path is also needed e.g `SchemaMigration`, `StatusService`.
I think we can define some `migration_path` method so that every service could use it.

What do you think about this problem and the solution? 🙂 