### PR TITLE
Take files only with .rb extension

### DIFF
--- a/lib/data_migrate/data_migrator.rb
+++ b/lib/data_migrate/data_migrator.rb
@@ -63,7 +63,7 @@ module DataMigrate
       # @param (String) filename
       # @return (MatchData)
       def match(filename)
-        /(\d{14})_(.+)\.rb/.match(filename)
+        /(\d{14})_(.+)\.rb$/.match(filename)
       end
 
       private

--- a/spec/data_migrate/status_service_spec.rb
+++ b/spec/data_migrate/status_service_spec.rb
@@ -62,6 +62,15 @@ describe DataMigrate::StatusService do
       expect(stream.read).to include expected
     end
 
+    it "excludes files without .rb extension" do
+      stream = StringIO.new
+      service.dump(ActiveRecord::Base.connection, stream)
+      stream.rewind
+
+      expected = "20181128000207  Excluded file"
+      expect(stream.read).to_not include expected
+    end
+
     it "shows missing file migration" do
       stream = StringIO.new
       service.dump(ActiveRecord::Base.connection, stream)

--- a/spec/db/data/20181128000207_excluded_file.rb.other_ext
+++ b/spec/db/data/20181128000207_excluded_file.rb.other_ext
@@ -1,0 +1,1 @@
+# This file should be excluded


### PR DESCRIPTION
Instead of taking all the files within `db/data/` (with the format "20091231235959_some_name.rb") with this change, it will only take the files with `.rb` extension.