### PR TITLE
Status service fix migration files path

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+## 5.3.0
+Add support to configure data migration path 
+
 ## 5.1.0
 Fixes to `db:schema:load:with_data` + `db:structure:load:with_data` definition, thanks to [craineum](https://github.com/craineum)
 

--- a/lib/data_migrate/config.rb
+++ b/lib/data_migrate/config.rb
@@ -15,7 +15,7 @@ module DataMigrate
     attr_accessor :data_migrations_path
 
     def initialize
-      @data_migrations_path = Dir.pwd + "/db/data/"
+      @data_migrations_path = File.join(Dir.pwd, "db/data/")
     end
   end
 end

--- a/lib/data_migrate/config.rb
+++ b/lib/data_migrate/config.rb
@@ -15,7 +15,7 @@ module DataMigrate
     attr_accessor :data_migrations_path
 
     def initialize
-      @data_migrations_path = "db/data/"
+      @data_migrations_path = Dir.pwd + "/db/data/"
     end
   end
 end

--- a/lib/data_migrate/data_migrator_five.rb
+++ b/lib/data_migrate/data_migrator_five.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 require "active_record"
+require "data_migrate/config"
 
 module DataMigrate
   class DataMigrator < ActiveRecord::Migrator
-    self.migrations_paths = ["db/data"]
+    self.migrations_paths = [DataMigrate.config.data_migrations_path]
 
     def self.assure_data_schema_table
       ActiveRecord::Base.establish_connection(db_config)

--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "data_migrate/config"
+
 module DataMigrate
   ##
   # This class extends DatabaseTasks to add a schema_file method.
@@ -26,7 +28,7 @@ module DataMigrate
     end
 
     def self.data_migrations_path
-      "db/data/"
+      DataMigrate.config.data_migrations_path
     end
 
     def self.schema_migrations_path

--- a/lib/data_migrate/status_service.rb
+++ b/lib/data_migrate/status_service.rb
@@ -11,10 +11,6 @@ module DataMigrate
       @connection = connection
     end
 
-    def root_folder
-      Rails.root
-    end
-
     def dump(stream)
       unless @connection.table_exists?(table_name)
         stream.puts "Data migrations table does not exist yet."
@@ -52,7 +48,7 @@ module DataMigrate
 
     def migration_files(db_list)
       file_list = []
-      Dir.foreach(File.join(root_folder, DataMigrate.config.data_migrations_path)) do |file|
+      Dir.foreach(DataMigrate.config.data_migrations_path) do |file|
         # only files matching "20091231235959_some_name.rb" pattern
         if match_data = DataMigrate::DataMigrator.match(file)
           status = db_list.delete(match_data[1]) ? "up" : "down"


### PR DESCRIPTION
Hi,
there's a problem with `StatusService` when under `data_migrations_path` is specified absolute path containing another directory than `Rails.root`.

Exactly here:
https://github.com/ilyakatz/data-migrate/blob/47c6acaf98876ed8977a24478808055cd64fd63a/lib/data_migrate/status_service.rb#L55

`File.join` adds `root_folder` to the absolute path causing an inexistent path.

The solution is to provide by default full path in `data_migrations_path`.
What do you think about this? 🙂 