### PR TITLE
Diff entire db directory for conditional deployment migrations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+## 5.3.0
+Add support to configure data migration path 
+
 ## 5.1.0
 Fixes to `db:schema:load:with_data` + `db:structure:load:with_data` definition, thanks to [craineum](https://github.com/craineum)
 

--- a/lib/capistrano/data_migrate/migrate.rb
+++ b/lib/capistrano/data_migrate/migrate.rb
@@ -1,33 +1,33 @@
 namespace :deploy do
 
-  desc 'Runs rake data:migrate if migrations are set'
-  Rake::Task['deploy:migrate'].clear_actions
+  desc "Runs rake data:migrate if migrations are set"
+  Rake::Task["deploy:migrate"].clear_actions
   task :migrate => [:set_rails_env] do
     on fetch(:migration_servers) do
       conditionally_migrate = fetch(:conditionally_migrate)
-      info '[deploy:migrate] Checking changes in db directory' if conditionally_migrate
+      info "[deploy:migrate] Checking changes in db directory" if conditionally_migrate
 
       if conditionally_migrate && test(:diff, "-qr #{release_path}/db #{current_path}/db")
-        info '[deploy:migrate] Skip `deploy:migrate` (nothing changed in db directory)'
+        info "[deploy:migrate] Skip `deploy:migrate` (nothing changed in db directory)"
       else
-        info '[deploy:migrate] Run `rake db:migrate:with_data`'
+        info "[deploy:migrate] Run `rake db:migrate:with_data`"
         invoke :'deploy:migrating_with_data'
       end
     end
   end
 
-  desc 'Runs rake db:migrate:with_data'
+  desc "Runs rake db:migrate:with_data"
   task migrating_with_data: [:set_rails_env] do
     on fetch(:migration_servers) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute :rake, 'db:migrate:with_data'
+          execute :rake, "db:migrate:with_data"
         end
       end
     end
   end
 
-  after 'deploy:updated', 'deploy:migrate'
+  after "deploy:updated", "deploy:migrate"
 end
 
 namespace :load do

--- a/lib/capistrano/data_migrate/migrate.rb
+++ b/lib/capistrano/data_migrate/migrate.rb
@@ -5,13 +5,10 @@ namespace :deploy do
   task :migrate => [:set_rails_env] do
     on fetch(:migration_servers) do
       conditionally_migrate = fetch(:conditionally_migrate)
-      info '[deploy:migrate] Checking changes in db/migrate or db/data' if conditionally_migrate
+      info '[deploy:migrate] Checking changes in db directory' if conditionally_migrate
 
-      if conditionally_migrate && (
-          test("diff -q #{release_path}/db/migrate #{current_path}/db/migrate") ||
-          test("diff -q #{release_path}/db/data #{current_path}/db/data")
-        )
-        info '[deploy:migrate] Skip `deploy:migrate` (nothing changed in db/migrate or db/data)'
+      if conditionally_migrate && test(:diff, "-qr #{release_path}/db #{current_path}/db")
+        info '[deploy:migrate] Skip `deploy:migrate` (nothing changed in db directory)'
       else
         info '[deploy:migrate] Run `rake db:migrate:with_data`'
         invoke :'deploy:migrating_with_data'

--- a/lib/data_migrate/data_migrator_five.rb
+++ b/lib/data_migrate/data_migrator_five.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 require "active_record"
+require "data_migrate/config"
 
 module DataMigrate
   class DataMigrator < ActiveRecord::Migrator
-    self.migrations_paths = ["db/data"]
+    self.migrations_paths = [DataMigrate.config.data_migrations_path]
 
     def self.assure_data_schema_table
       ActiveRecord::Base.establish_connection(db_config)

--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "data_migrate/config"
+
 module DataMigrate
   ##
   # This class extends DatabaseTasks to add a schema_file method.
@@ -26,7 +28,7 @@ module DataMigrate
     end
 
     def self.data_migrations_path
-      "db/data/"
+      DataMigrate.config.data_migrations_path
     end
 
     def self.schema_migrations_path


### PR DESCRIPTION
Previously, if you were using the `conditionally_migrate` flag and only added a data migration to `db/data`, the migrations would be skipped on capistrano deploy. Recursively checking the entire db directory is the way it's done in the `capistrano/rails` project (https://github.com/capistrano/rails/blob/master/lib/capistrano/tasks/migrations.rake#L10).