### PR TITLE
Fix triggering conditional migrations in the capistrano task

### DIFF
--- a/lib/capistrano/data_migrate/migrate.rb
+++ b/lib/capistrano/data_migrate/migrate.rb
@@ -8,8 +8,8 @@ namespace :deploy do
       info '[deploy:migrate] Checking changes in db/migrate or db/data' if conditionally_migrate
 
       if conditionally_migrate &&
-          test("diff -q #{release_path}/db/migrate #{current_path}/db/migrate") &&
-          test("diff -q #{release_path}/db/data #{current_path}/db/data")
+         test("diff -q #{release_path}/db/migrate #{current_path}/db/migrate") &&
+         test("diff -q #{release_path}/db/data #{current_path}/db/data")
         info '[deploy:migrate] Skip `deploy:migrate` (nothing changed in db/migrate or db/data)'
       else
         info '[deploy:migrate] Run `rake db:migrate:with_data`'

--- a/lib/capistrano/data_migrate/migrate.rb
+++ b/lib/capistrano/data_migrate/migrate.rb
@@ -7,10 +7,9 @@ namespace :deploy do
       conditionally_migrate = fetch(:conditionally_migrate)
       info '[deploy:migrate] Checking changes in db/migrate or db/data' if conditionally_migrate
 
-      if conditionally_migrate && (
-          test("diff -q #{release_path}/db/migrate #{current_path}/db/migrate") ||
+      if conditionally_migrate &&
+          test("diff -q #{release_path}/db/migrate #{current_path}/db/migrate") &&
           test("diff -q #{release_path}/db/data #{current_path}/db/data")
-        )
         info '[deploy:migrate] Skip `deploy:migrate` (nothing changed in db/migrate or db/data)'
       else
         info '[deploy:migrate] Run `rake db:migrate:with_data`'


### PR DESCRIPTION
This is a fix for a small bug described in #110 that prevents triggering conditional migrations when only _one_ of the `schema` and `data` migration dirs changes. The condition must ensure that _both_ diff commands exited gracefully (i.e. that there are no changes in _any_ of the two dirs) to skip running migrations.

Recently I noticed that a similar PR #108 is solving the same issue in a different way (it diffs the whole `db` directory). Personally, I rather like when code deals with its own environment and nothing else but for sure I leave the final decision to the maintainers :).

Also I notice that custom data migrations path option has been added to the gem but using it would break this capistrano task, but that would be work for another PR. Thanks!