### PR TITLE
Add support for Rails 6.0.0.rc2

### DIFF
--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -2,7 +2,7 @@
 
 source "http://rubygems.org"
 
-gem "rails", "~> 6.0.0.beta3"
+gem "rails", "~> 6.0.0.rc2"
 gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/lib/data_migrate.rb
+++ b/lib/data_migrate.rb
@@ -14,7 +14,7 @@ require File.join(File.dirname(__FILE__), "data_migrate", "database_tasks")
 require File.join(File.dirname(__FILE__), "data_migrate", "schema_dumper")
 if Rails::VERSION::MAJOR == 6
   require File.join(File.dirname(__FILE__), "data_migrate", "status_service_five")
-  require File.join(File.dirname(__FILE__), "data_migrate", "schema_migration_five")
+  require File.join(File.dirname(__FILE__), "data_migrate", "schema_migration_six")
 elsif Rails::VERSION::MAJOR == 5 &&  Rails::VERSION::MINOR == 2
   require File.join(File.dirname(__FILE__), "data_migrate", "status_service_five")
   require File.join(File.dirname(__FILE__), "data_migrate", "schema_migration_five")

--- a/lib/data_migrate/schema_migration_six.rb
+++ b/lib/data_migrate/schema_migration_six.rb
@@ -1,0 +1,31 @@
+module DataMigrate
+  # Helper class to getting access to db schema
+  # to allow data/schema combiation tasks
+  class SchemaMigration
+    def self.pending_schema_migrations
+      all_migrations = DataMigrate::MigrationContext.new(migrations_paths).migrations
+      sort_migrations(
+        ActiveRecord::Migrator.new(:up, all_migrations, ActiveRecord::Base.connection.schema_migration).
+        pending_migrations.
+        map {|m| { version: m.version, kind: :schema }}
+      )
+    end
+
+    def self.run(direction, migration_paths, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::Base.connection.schema_migration).run(direction, version)
+    end
+
+    def self.sort_migrations(set1, set2 = nil)
+      migrations = set1 + (set2 || [])
+      migrations.sort {|a, b|  sort_string(a) <=> sort_string(b)}
+    end
+
+    def self.migrations_paths
+      Rails.application.config.paths["db/migrate"].to_a
+    end
+
+    def self.sort_string(migration)
+      "#{migration[:version]}_#{migration[:kind] == :data ? 1 : 0}"
+    end
+  end
+end

--- a/spec/data_migrate/migration_context_spec.rb
+++ b/spec/data_migrate/migration_context_spec.rb
@@ -10,7 +10,7 @@ describe DataMigrate::DataMigrator do
   }
   let(:schema_context) {
     if (Rails::VERSION::MAJOR == 6)
-      ActiveRecord::MigrationContext.new("spec/db/migrate/6.0")
+      ActiveRecord::MigrationContext.new("spec/db/migrate/6.0", ActiveRecord::Base.connection.schema_migration)
     else
       ActiveRecord::MigrationContext.new("spec/db/migrate/5.2")
     end


### PR DESCRIPTION
Since https://github.com/rails/rails/pull/36439, initialize of `Migrator` and `MigrationContext` require schema migration.

This fixed to specify schema migration for each which can be obtained from a connection.