### PR TITLE
Add :abort_if_pending_migrations rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,26 +82,29 @@ You can generate a data migration as you would a schema migration:
 ### Rake Tasks
 
     $> rake -T data
-    rake data:dump                    # Create a db/data_schema.rb file that stores the current data version
-    rake data:forward                 # Pushes the schema to the next version (specify steps w/ STEP=n)
-    rake data:migrate                 # Migrate data migrations (options: VERSION=x, VERBOSE=false)
-    rake data:migrate:down            # Runs the "down" for a given migration VERSION
-    rake data:migrate:redo            # Rollbacks the database one migration and re migrate up (options: STEP=x, VERSION=x)
-    rake data:migrate:status          # Display status of data migrations
-    rake data:migrate:up              # Runs the "up" for a given migration VERSION
-    rake data:rollback                # Rolls the schema back to the previous version (specify steps w/ STEP=n)
-    rake data:schema:load             # Load data_schema.rb file into the database without running the data migrations
-    rake data:version                 # Retrieves the current schema version number for data migrations
-    rake db:forward:with_data         # Pushes the schema to the next version (specify steps w/ STEP=n)
-    rake db:migrate:down:with_data    # Runs the "down" for a given migration VERSION
-    rake db:migrate:redo:with_data    # Rollbacks the database one migration and re migrate up (options: STEP=x, VERSION=x)
-    rake db:migrate:status:with_data  # Display status of data and schema migrations
-    rake db:migrate:up:with_data      # Runs the "up" for a given migration VERSION
-    rake db:migrate:with_data         # Migrate the database data and schema (options: VERSION=x, VERBOSE=false)
-    rake db:rollback:with_data        # Rolls the schema back to the previous version (specify steps w/ STEP=n)
-    rake db:schema:load:with_data     # Load both schema.rb and data_schema.rb files into the database
-    rake db:structure:load:with_data  # Load both structure.sql and data_schema.rb files into the database
-    rake db:version:with_data         # Retrieves the current schema version numbers for data and schema migrations
+    rake data:abort_if_pending_migrations          # Raises an error if there are pending data migrations
+    rake data:dump                                 # Create a db/data_schema.rb file that stores the current data version
+    rake data:forward                              # Pushes the schema to the next version (specify steps w/ STEP=n)
+    rake data:migrate                              # Migrate data migrations (options: VERSION=x, VERBOSE=false)
+    rake data:migrate:down                         # Runs the "down" for a given migration VERSION
+    rake data:migrate:redo                         # Rollbacks the database one migration and re migrate up (options: STEP=x, VERSION=x)
+    rake data:migrate:status                       # Display status of data migrations
+    rake data:migrate:up                           # Runs the "up" for a given migration VERSION
+    rake data:rollback                             # Rolls the schema back to the previous version (specify steps w/ STEP=n)
+    rake data:schema:load                          # Load data_schema.rb file into the database without running the data migrations
+    rake data:version                              # Retrieves the current schema version number for data migrations
+    rake db:abort_if_pending_migrations:with_data  # Raises an error if there are pending migrations or data migrations
+    rake db:forward:with_data                      # Pushes the schema to the next version (specify steps w/ STEP=n)
+    rake db:migrate:down:with_data                 # Runs the "down" for a given migration VERSION
+    rake db:migrate:redo:with_data                 # Rollbacks the database one migration and re migrate up (options: STEP=x, VERSION=x)
+    rake db:migrate:status:with_data               # Display status of data and schema migrations
+    rake db:migrate:up:with_data                   # Runs the "up" for a given migration VERSION
+    rake db:migrate:with_data                      # Migrate the database data and schema (options: VERSION=x, VERBOSE=false)
+    rake db:rollback:with_data                     # Rolls the schema back to the previous version (specify steps w/ STEP=n)
+    rake db:schema:load:with_data                  # Load both schema.rb and data_schema.rb file into the database
+    rake db:structure:load:with_data               # Load both structure.sql and data_schema.rb file into the database
+    rake db:version:with_data                      # Retrieves the current schema version numbers for data and schema migrations
+
 
 Tasks work as they would with the 'vanilla' db version. The 'with_data' addition to the 'db' tasks will run the task in the context of both the data and schema migrations. That is, rake db:rollback:with_data will check to see if it was a schema or data migration invoked last, and do that. Tasks invoked in that space also have an additional line of output, indicating if the action is performed on data or schema.
 

--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -69,7 +69,7 @@ module DataMigrate
     def self.pending_data_migrations
       data_migrations = DataMigrate::DataMigrator.migrations(data_migrations_path)
       sort_migrations(DataMigrate::DataMigrator.new(:up, data_migrations ).
-        pending_migrations.map {|m| { version: m.version, kind: :data }})
+        pending_migrations.map {|m| { version: m.version, name: m.name, kind: :data }})
     end
 
     def self.pending_schema_migrations

--- a/lib/data_migrate/schema_migration.rb
+++ b/lib/data_migrate/schema_migration.rb
@@ -7,7 +7,7 @@ module DataMigrate
       sort_migrations(
         ActiveRecord::Migrator.new(:up, all_migrations).
         pending_migrations.
-        map {|m| { version: m.version, kind: :schema }}
+        map {|m| { version: m.version, name: m.name, kind: :schema }}
       )
     end
 

--- a/lib/data_migrate/schema_migration_five.rb
+++ b/lib/data_migrate/schema_migration_five.rb
@@ -7,7 +7,7 @@ module DataMigrate
       sort_migrations(
         ActiveRecord::Migrator.new(:up, all_migrations).
         pending_migrations.
-        map {|m| { version: m.version, kind: :schema }}
+        map {|m| { version: m.version, name: m.name, kind: :schema }}
       )
     end
 

--- a/lib/data_migrate/tasks/data_migrate_tasks.rb
+++ b/lib/data_migrate/tasks/data_migrate_tasks.rb
@@ -16,6 +16,16 @@ module DataMigrate
           DataMigrate::DataMigrator.migrate(migrations_paths, ENV["VERSION"] ? ENV["VERSION"].to_i : nil)
         end
       end
+
+      def abort_if_pending_migrations(migrations, message)
+        if migrations.any?
+          puts "You have #{migrations.size} pending #{migrations.size > 1 ? 'migrations:' : 'migration:'}"
+          migrations.each do |pending_migration|
+            puts "  %4d %s" % [pending_migration[:version], pending_migration[:name]]
+          end
+          abort message
+        end
+      end
     end
   end
 end

--- a/spec/data_migrate/tasks/data_migrate_tasks_spec.rb
+++ b/spec/data_migrate/tasks/data_migrate_tasks_spec.rb
@@ -3,23 +3,23 @@
 require "spec_helper"
 
 describe DataMigrate::Tasks::DataMigrateTasks do
-  let(:db_config) do
-    {
-      adapter: "sqlite3",
-      database: "spec/db/test.db"
-    }
-  end
-
-  before do
-    allow(DataMigrate::DataMigrator).to receive(:db_config) { db_config }
-    ActiveRecord::Base.establish_connection(db_config)
-  end
-
-  after do
-    ActiveRecord::Migration.drop_table("data_migrations")
-  end
-
   describe :migrate do
+    let(:db_config) do
+      {
+        adapter: "sqlite3",
+        database: "spec/db/test.db"
+      }
+    end
+  
+    before do
+      allow(DataMigrate::DataMigrator).to receive(:db_config) { db_config }
+      ActiveRecord::Base.establish_connection(db_config)
+    end
+  
+    after do
+      ActiveRecord::Migration.drop_table("data_migrations")
+    end
+
     it do
        expect {
         DataMigrate::Tasks::DataMigrateTasks.migrate
@@ -30,6 +30,38 @@ describe DataMigrate::Tasks::DataMigrateTasks do
       expect {
         DataMigrate::Tasks::DataMigrateTasks.migrate
       }.to output(/20171231235959 SuperUpdate: migrating/).to_stdout
+    end
+  end
+
+  describe :abort_if_pending_migrations do
+    subject { DataMigrate::Tasks::DataMigrateTasks.abort_if_pending_migrations(migrations, message) }
+
+    let(:message) { "ABORT_MESSAGE" }
+
+    context "when there are no pending migrations" do
+      let(:migrations) { [] }
+
+      it "shouldn't do anything" do
+        expect { subject }.to_not raise_error
+      end
+    end
+
+    context "when there are pending migrations" do
+      let(:migrations) do
+        [{
+          name: "A",
+          version: 1
+        }, {
+          name: 'B',
+          version: 2
+        }] 
+      end
+      
+      it "should abort with given message and print names and versions of pending migrations" do
+        expect { subject }
+          .to raise_error(SystemExit, message)
+          .and output("You have 2 pending migrations:\n     1 A\n     2 B\n").to_stdout
+      end
     end
   end
 end

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -223,6 +223,14 @@ namespace :db do
     end
   end
 
+  namespace :abort_if_pending_migrations do
+    desc "Raises an error if there are pending migrations or data migrations"
+    task with_data: :environment do
+      message = %{Run `rake db:migrate:with_data` to update your database then try again.}
+      DataMigrate::Tasks::DataMigrateTasks.abort_if_pending_migrations(pending_migrations, message)
+    end
+  end
+
   namespace :schema do
     namespace :load do
       desc "Load both schema.rb and data_schema.rb file into the database"
@@ -325,6 +333,12 @@ namespace :data do
   task :version => :environment do
     assure_data_schema_table
     puts "Current data version: #{DataMigrate::DataMigrator.current_version}"
+  end
+
+  desc "Raises an error if there are pending data migrations"
+  task abort_if_pending_migrations: :environment do
+    message = %{Run `rake data:migrate` to update your database then try again.}
+    DataMigrate::Tasks::DataMigrateTasks.abort_if_pending_migrations(pending_data_migrations, message)
   end
 
   desc "Create a db/data_schema.rb file that stores the current data version"


### PR DESCRIPTION
Added 
```
rake data:abort_if_pending_migrations
rake db:abort_if_pending_migrations:with_data
```
as an addition / extension to
```
rake db:abort_if_pending_migrations
```
provided by rails.

The new tasks could be useful during deployment process to ensure that all data migrations have been executed before starting the servers.

In the project that I'm currently working on, we use `rake db:abort_if_pending_migrations` during deployment pipeline to ensure that ActiveRecord migrations have been executed before starting the servers. We would like to extend that to data migrations as well. 