### PR TITLE
Add needs_migration? option for Rails 5.2 and above

### DIFF
--- a/lib/data_migrate/data_migrator_five.rb
+++ b/lib/data_migrate/data_migrator_five.rb
@@ -45,6 +45,9 @@ module DataMigrate
         /(\d{14})_(.+)\.rb/.match(filename)
       end
 
+      def needs_migration?
+        DataMigrate::DatabaseTasks.pending_migrations.count.positive?
+      end
       ##
       # Provides the full migrations_path filepath
       # @return (String)


### PR DESCRIPTION
The needs_migration? option no longer works in Rails 5.2 and above. This PR adds a custom check for it