### PR TITLE
Rollback fix for Rails 5.2.

### DIFF
--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -194,7 +194,7 @@ namespace :db do
           DataMigrate::DataMigrator.run(:down, data_migrations_path, past_migration[:version])
         elsif past_migration[:kind] == :schema
           ActiveRecord::Migration.write("== %s %s" % ['Schema', "=" * 69])
-          ActiveRecord::Migrator.run(:down, "db/migrate/", past_migration[:version])
+          DataMigrate::SchemaMigration.run(:down, "db/migrate/", past_migration[:version])
         end
       end
 


### PR DESCRIPTION
Using `ActiveRecord::Migrator.run` appears to break `db:rollback` in Rails 5.2
Since this is just executing a `db:down`, I propose using the same logic here.

[rollback_failure.txt](https://github.com/ilyakatz/data-migrate/files/3610907/rollback_failure.txt)
