### PR TITLE
Data schema load

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can generate a data migration as you would a schema migration:
     rake data:migrate:status          # Display status of data migrations
     rake data:migrate:up              # Runs the "up" for a given migration VERSION
     rake data:rollback                # Rolls the schema back to the previous version (specify steps w/ STEP=n)
-    rake data:schema:load             # Load data_schema.rb file into the database
+    rake data:schema:load             # Load data_schema.rb file into the database without running the data migrations
     rake data:version                 # Retrieves the current schema version number for data migrations
     rake db:forward:with_data         # Pushes the schema to the next version (specify steps w/ STEP=n)
     rake db:migrate:down:with_data    # Runs the "down" for a given migration VERSION

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ You can generate a data migration as you would a schema migration:
     rake data:migrate:status          # Display status of data migrations
     rake data:migrate:up              # Runs the "up" for a given migration VERSION
     rake data:rollback                # Rolls the schema back to the previous version (specify steps w/ STEP=n)
+    rake data:schema:load             # Load data_schema.rb file into the database
     rake data:version                 # Retrieves the current schema version number for data migrations
     rake db:forward:with_data         # Pushes the schema to the next version (specify steps w/ STEP=n)
     rake db:migrate:down:with_data    # Runs the "down" for a given migration VERSION

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -341,6 +341,16 @@ namespace :data do
     # that depend on this one.
     Rake::Task["data:dump"].reenable
   end
+  
+  namespace :schema do
+    desc "Load data_schema.rb file into the database"
+    task load: :environment do
+      DataMigrate::DatabaseTasks.load_schema_current(
+        :ruby,
+        ENV["DATA_SCHEMA"]
+      )
+    end
+  end
 end
 
 def pending_migrations


### PR DESCRIPTION
Seems to be the only missing rake task.
Allows end user to run this task to load the data_migration schema without specifically reloading the schema or the structure.sql.