### PR TITLE
Allow data dump connection to be configured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.lock
 gemfiles/.bundle
 spec/db/test.db
+spec/db/other_test.db
+spec/db/data_schema.rb
 .vscode/
 .DS_Store
 .idea/

--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ You can override this setting in `config/initializers/data_migrate.rb`
 ```ruby
 DataMigrate.configure do |config|
   config.data_migrations_path = "db/awesomepath/"
+  config.db_configuration = {
+    'host' => '127.0.0.1',
+    'database' => 'awesome_database',
+    'adapter' => 'mysql2',
+    'username' => 'root',
+    'password' => nil,
+  }
 end
 
 ```

--- a/lib/data_migrate/config.rb
+++ b/lib/data_migrate/config.rb
@@ -16,7 +16,7 @@ module DataMigrate
 
     def initialize
       @data_migrations_path = "db/data/"
-      @db_configuration = nil
+      @db_configuration = ActiveRecord::Base.connection_config
     end
   end
 end

--- a/lib/data_migrate/config.rb
+++ b/lib/data_migrate/config.rb
@@ -16,7 +16,7 @@ module DataMigrate
 
     def initialize
       @data_migrations_path = "db/data/"
-      @db_configuration = ActiveRecord::Base.connection_config
+      @db_configuration = nil
     end
   end
 end

--- a/lib/data_migrate/config.rb
+++ b/lib/data_migrate/config.rb
@@ -12,10 +12,11 @@ module DataMigrate
   end
 
   class Config
-    attr_accessor :data_migrations_path
+    attr_accessor :data_migrations_path, :db_configuration
 
     def initialize
       @data_migrations_path = "db/data/"
+      @db_configuration = nil
     end
   end
 end

--- a/lib/data_migrate/tasks/data_migrate_tasks.rb
+++ b/lib/data_migrate/tasks/data_migrate_tasks.rb
@@ -6,6 +6,16 @@ module DataMigrate
         @migrations_paths ||= DataMigrate.config.data_migrations_path
       end
 
+      def dump
+        if ActiveRecord::Base.dump_schema_after_migration
+          filename = DataMigrate::DatabaseTasks.schema_file
+          ActiveRecord::Base.establish_connection(DataMigrate.config.db_configuration) if DataMigrate.config.db_configuration
+          File.open(filename, "w:utf-8") do |file|
+            DataMigrate::SchemaDumper.dump(ActiveRecord::Base.connection, file)
+          end
+        end
+      end
+
       def migrate
         DataMigrate::DataMigrator.assure_data_schema_table
         target_version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil

--- a/spec/data_migrate/tasks/data_migrate_tasks_spec.rb
+++ b/spec/data_migrate/tasks/data_migrate_tasks_spec.rb
@@ -3,6 +3,57 @@
 require "spec_helper"
 
 describe DataMigrate::Tasks::DataMigrateTasks do
+  describe :dump do
+    let(:db_config) do
+      {
+        adapter: "sqlite3",
+        database: "spec/db/other_test.db"
+      }
+    end
+
+    before do
+      allow(DataMigrate::DataMigrator).to receive(:db_config) { db_config }
+      allow(DataMigrate::DatabaseTasks).to receive(:db_dir).and_return("spec/db")
+    end
+
+    after do
+      ActiveRecord::Migration.drop_table("data_migrations")
+    end
+
+    context 'when not given a separate db config' do
+      it 'does not override the default connection' do
+        DataMigrate::Tasks::DataMigrateTasks.migrate
+        expect(ActiveRecord::Base).not_to receive(:establish_connection)
+        expect(DataMigrate::SchemaDumper).to receive(:dump)
+        DataMigrate::Tasks::DataMigrateTasks.dump
+      end
+    end
+
+    context 'when given ' do
+      let(:override_config) do
+        {
+          'host' => '127.0.0.1',
+          'database' => 'other_test',
+          'adapter' => 'sqlite3',
+          'username' => 'root',
+          'password' => nil,
+        }
+      end
+
+      before do
+        DataMigrate.configure do |config|
+          config.db_configuration = override_config
+        end
+      end
+
+      it 'overrides the default connection' do
+        DataMigrate::Tasks::DataMigrateTasks.migrate
+        expect(ActiveRecord::Base).to receive(:establish_connection).with(override_config)
+        DataMigrate::Tasks::DataMigrateTasks.dump
+      end
+    end
+  end
+
   describe :migrate do
     let(:db_config) do
       {
@@ -10,12 +61,12 @@ describe DataMigrate::Tasks::DataMigrateTasks do
         database: "spec/db/test.db"
       }
     end
-  
+
     before do
       allow(DataMigrate::DataMigrator).to receive(:db_config) { db_config }
       ActiveRecord::Base.establish_connection(db_config)
     end
-  
+
     after do
       ActiveRecord::Migration.drop_table("data_migrations")
     end
@@ -54,9 +105,9 @@ describe DataMigrate::Tasks::DataMigrateTasks do
         }, {
           name: 'B',
           version: 2
-        }] 
+        }]
       end
-      
+
       it "should abort with given message and print names and versions of pending migrations" do
         expect { subject }
           .to raise_error(SystemExit, message)

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -343,13 +343,7 @@ namespace :data do
 
   desc "Create a db/data_schema.rb file that stores the current data version"
   task dump: :environment do
-    if ActiveRecord::Base.dump_schema_after_migration
-      filename = DataMigrate::DatabaseTasks.schema_file
-      ActiveRecord::Base.establish_connection(DataMigrate.config.db_configuration) if DataMigrate.config.db_configuration
-      File.open(filename, "w:utf-8") do |file|
-        DataMigrate::SchemaDumper.dump(ActiveRecord::Base.connection, file)
-      end
-    end
+    DataMigrate::Tasks::DataMigrateTasks.dump
 
     # Allow this task to be called as many times as required. An example
     # is the migrate:redo task, which calls other two internally

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -345,7 +345,7 @@ namespace :data do
   task dump: :environment do
     if ActiveRecord::Base.dump_schema_after_migration
       filename = DataMigrate::DatabaseTasks.schema_file
-      ActiveRecord::Base.establish_connection(DataMigrate.config.db_configuration)
+      ActiveRecord::Base.establish_connection(DataMigrate.config.db_configuration) if DataMigrate.config.db_configuration
       File.open(filename, "w:utf-8") do |file|
         DataMigrate::SchemaDumper.dump(ActiveRecord::Base.connection, file)
       end

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -345,8 +345,8 @@ namespace :data do
   task dump: :environment do
     if ActiveRecord::Base.dump_schema_after_migration
       filename = DataMigrate::DatabaseTasks.schema_file
+      ActiveRecord::Base.establish_connection(DataMigrate.config.db_configuration)
       File.open(filename, "w:utf-8") do |file|
-        ActiveRecord::Base.establish_connection(DataMigrate.config.db_configuration)
         DataMigrate::SchemaDumper.dump(ActiveRecord::Base.connection, file)
       end
     end

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -346,6 +346,7 @@ namespace :data do
     if ActiveRecord::Base.dump_schema_after_migration
       filename = DataMigrate::DatabaseTasks.schema_file
       File.open(filename, "w:utf-8") do |file|
+        ActiveRecord::Base.establish_connection(DataMigrate.config.db_configuration)
         DataMigrate::SchemaDumper.dump(ActiveRecord::Base.connection, file)
       end
     end
@@ -355,7 +356,7 @@ namespace :data do
     # that depend on this one.
     Rake::Task["data:dump"].reenable
   end
-  
+
   namespace :schema do
     desc "Load data_schema.rb file into the database"
     task load: :environment do


### PR DESCRIPTION
In an effort to help address this issue with multiple databases: https://github.com/ilyakatz/data-migrate/issues/147, allowing the database connection to be configured. Then we connect to the configured database before running the data dump.