### PR TITLE
feature: Generate a spec file.

### DIFF
--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -16,6 +16,10 @@ module DataMigrate
         set_local_assigns!
         migration_template "data_migration.rb", data_migrations_file_path
       end
+      
+      def create_data_migration_spec
+        template "data_migration_spec.rb", data_migrations_spec_path
+      end
 
       protected
 
@@ -38,6 +42,22 @@ module DataMigrate
 
       def data_migrations_file_path
         File.join(data_migrations_path, "#{file_name}.rb")
+      end
+      
+      # The path to the real generated migration.
+      def data_migrations_load_path
+        File.join(
+          data_migrations_path,
+          [@migration_number, "#{file_name}.rb"].join("_")
+        )
+      end
+      
+      def data_migrations_spec_path
+        File.join(
+          "spec",
+          data_migrations_path,
+          [@migration_number, "#{file_name}_spec.rb"].join("_")
+        )
       end
 
       def data_migrations_path

--- a/lib/generators/data_migration/templates/data_migration_spec.rb
+++ b/lib/generators/data_migration/templates/data_migration_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+require Rails.root.join(%q{<%= data_migrations_load_path %>})
+
+describe <%= migration_class_name %> do
+  let(:migrator) {
+    described_class.new.tap do |m|
+      m.verbose = false
+    end
+  }
+
+  describe "#up" do
+    subject { migrator.migrate(:up) }
+
+    pending "Needs tests"
+  end
+
+  describe "#down" do
+    subject { migrator.migrate(:down) }
+
+    pending "Needs tests"
+  end
+end

--- a/spec/generators/data_migration/data_migration_generator_spec.rb
+++ b/spec/generators/data_migration/data_migration_generator_spec.rb
@@ -57,4 +57,21 @@ describe DataMigrate::Generators::DataMigrationGenerator do
       end
     end
   end
+  
+  describe :create_data_migration_spec do
+    let(:subject) { DataMigrate::Generators::DataMigrationGenerator.new(['my_migration']) }
+    let(:data_migrations_spec_path) { 'spec/abc/my_migration_spec.rb' }
+    
+    before do
+      DataMigrate.config.data_migrations_path = 'abc/'
+    end
+    
+    it 'returns correct file path' do
+      expect(subject).to receive(:migration_template).with(
+        'data_migration_spec.rb', data_migrations_spec_path
+      )
+
+      subject.create_data_migration_spec
+    end
+  end
 end


### PR DESCRIPTION
Unlike schema migrations, data migrations are easy to test but require a bit of special setup. This adds a spec file to the generator.

* Loads the migration.
* Sets up the a quiet migrator object.
* Basic describe up/down blocks with subjects.

Closes #148 