### PR TITLE
Fix db configurations hash access deprecation in Rails 6.1

### DIFF
--- a/lib/data_migrate/data_migrator_five.rb
+++ b/lib/data_migrate/data_migrator_five.rb
@@ -75,8 +75,13 @@ module DataMigrate
       end
 
       def db_config
-        ActiveRecord::Base.configurations[Rails.env || "development"] ||
-          ENV["DATABASE_URL"]
+        env = Rails.env || "development"
+        ar_config = if Rails::VERSION::MAJOR >= 6
+                      ActiveRecord::Base.configurations.configs_for(env_name: env).first
+                    else
+                      ActiveRecord::Base.configurations[env]
+                    end
+        ar_config || ENV["DATABASE_URL"]
       end
     end
 


### PR DESCRIPTION
This PR fixes the following deprecation [newly occurring](https://github.com/rails/rails/blob/6-1-stable/activerecord/lib/active_record/database_configurations.rb#L75) in Rails 6.1:

```
ActiveSupport::DeprecationException: DEPRECATION WARNING: [] is deprecated and will be removed from Rails 6.2
(Use configs_for).

.../vendor/bundle/ruby/2.6.0/gems/data_migrate-6.6.0/lib/data_migrate/data_migrator_five.rb:78:in `db_config'
.../vendor/bundle/ruby/2.6.0/gems/data_migrate-6.6.0/lib/data_migrate/data_migrator_five.rb:13:in `assure_data_schema_table'
.../vendor/bundle/ruby/2.6.0/gems/data_migrate-6.6.0/tasks/databases.rake:409:in `assure_data_schema_table'
```

It seems that the `configs_for` API is actually available [since Rails 6.0](https://github.com/rails/rails/blob/6-0-stable/activerecord/lib/active_record/database_configurations.rb#L38) so that's why I check only for the major Rails version.

Also, I noticed that most of that Rails versions handling is inside `data_migrate.rb` but as this is only a one-line change I didn't feel it deserves a whole new file to be copy-edited (something like `data_migrator_six.rb`) but if it is preferred, I can of course amend the PR that way.

Thanks!