### PR TITLE
Fix db configurations hash access deprecation

### DIFF
--- a/lib/data_migrate/data_migrator_five.rb
+++ b/lib/data_migrate/data_migrator_five.rb
@@ -75,8 +75,13 @@ module DataMigrate
       end
 
       def db_config
-        ActiveRecord::Base.configurations[Rails.env || "development"] ||
-          ENV["DATABASE_URL"]
+        env = Rails.env || "development"
+        ar_config = if (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR >= 1) || Rails::VERSION::MAJOR > 6
+                      ActiveRecord::Base.configurations.configs_for(env_name: env).first
+                    else
+                      ActiveRecord::Base.configurations[env]
+                    end
+        ar_config || ENV["DATABASE_URL"]
       end
     end
 


### PR DESCRIPTION
This is a followup of #172 and #166 . The only change compared to #166 is the minimum version required for the new behavior. At least Rails 6.1 is required now and the code tries to be future Rails 7.0 version-compatible, too.

---

Fixes "ActiveSupport::DeprecationException: DEPRECATION WARNING: [] is deprecated and will be removed from Rails 6.2 (Use configs_for)".

The `configs_for` API is available since Rails 6.1.