### PR TITLE
Fix db configurations hash access deprecation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 
+## 6.6.2
 ## 6.6.1
 
 configs_for deprecation notice [borama](https://github.com/borama)

--- a/lib/data_migrate/data_migrator_five.rb
+++ b/lib/data_migrate/data_migrator_five.rb
@@ -75,8 +75,13 @@ module DataMigrate
       end
 
       def db_config
-        ActiveRecord::Base.configurations[Rails.env || "development"] ||
-          ENV["DATABASE_URL"]
+        env = Rails.env || "development"
+        ar_config = if (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR >= 1) || Rails::VERSION::MAJOR > 6
+                      ActiveRecord::Base.configurations.configs_for(env_name: env).first
+                    else
+                      ActiveRecord::Base.configurations[env]
+                    end
+        ar_config || ENV["DATABASE_URL"]
       end
     end
 

--- a/lib/data_migrate/version.rb
+++ b/lib/data_migrate/version.rb
@@ -1,3 +1,3 @@
 module DataMigrate
-  VERSION = "6.6.1".freeze
+  VERSION = "6.6.2".freeze
 end


### PR DESCRIPTION
Fixes "ActiveSupport::DeprecationException: DEPRECATION WARNING: [] is deprecated and will be removed from Rails 6.2 (Use configs_for)".

The `configs_for` API is available since Rails 6.1.