### PR TITLE
Fix DataMigrator#match regex

### DIFF
--- a/lib/data_migrate/data_migrator_five.rb
+++ b/lib/data_migrate/data_migrator_five.rb
@@ -42,7 +42,7 @@ module DataMigrate
       # @param (String) filename
       # @return (MatchData)
       def match(filename)
-        /(\d{14})_(.+)\.rb/.match(filename)
+        /(\d{14})_(.+)\.rb$/.match(filename)
       end
 
       def needs_migration?

--- a/spec/data_migrate/data_migrator_spec.rb
+++ b/spec/data_migrate/data_migrator_spec.rb
@@ -82,6 +82,12 @@ describe DataMigrate::DataMigrator do
       end
     end
 
+    context "when the file doesn't end in .rb" do
+      it "returns nil" do
+        expect(subject.match("20091231235959_some_name.rb.un~")).to be_nil
+      end
+    end
+
     context "when the file matches" do
       it "returns a valid MatchData object" do
         match_data = subject.match("20091231235959_some_name.rb")


### PR DESCRIPTION
Fixes an issue where the data migrator matches files in the migration directory that don't end in `.rb`. I encountered this personally when some vim .un~ (undo) files were present in the directory, causing `Duplicate data migration ...` errors from `rails data:schema:load`.

This is basically the same fix that was applied to the legacy data migrator in 76b937e3b20f5ff001d2755dd4819b1f4d4ebc07