### PR TITLE
Fix a typo in Changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 ## 7.0.1
-Use SchemaMigrations.migration_paths in main rake task [lewhit](https://github.com/lewhit)
+Use SchemaMigration.migrations_paths in main rake task [lewhit](https://github.com/lewhit)
 
 ## 6.8.0
 


### PR DESCRIPTION
It seems method name is `SchemaMigration.migrations_paths`.