### PR TITLE
Remove magic comment in generated `data_schema.rb`

### DIFF
--- a/lib/data_migrate/schema_dumper.rb
+++ b/lib/data_migrate/schema_dumper.rb
@@ -17,10 +17,6 @@ module DataMigrate
     def dump(stream)
       define_params = @version ? "version: #{@version}" : ""
 
-      if stream.respond_to?(:external_encoding) && stream.external_encoding
-        stream.puts "# encoding: #{stream.external_encoding.name}"
-      end
-
       stream.puts "DataMigrate::Data.define(#{define_params})"
 
       stream

--- a/spec/db/data/partial_schema/data_schema.rb
+++ b/spec/db/data/partial_schema/data_schema.rb
@@ -1,2 +1,1 @@
-# encoding: UTF-8
 DataMigrate::Data.define(version: 20091231235959)

--- a/spec/db/data/partial_schema/test_data_schema.rb
+++ b/spec/db/data/partial_schema/test_data_schema.rb
@@ -1,2 +1,1 @@
-# encoding: UTF-8
 DataMigrate::Data.define(version: 20091231235959)

--- a/spec/db/data/schema/data_schema.rb
+++ b/spec/db/data/schema/data_schema.rb
@@ -1,2 +1,1 @@
-# encoding: UTF-8
 DataMigrate::Data.define(version: 20171231235959)

--- a/spec/db/data/schema/test_data_schema.rb
+++ b/spec/db/data/schema/test_data_schema.rb
@@ -1,2 +1,1 @@
-# encoding: UTF-8
 DataMigrate::Data.define(version: 20171231235959)


### PR DESCRIPTION
`data_migrate` only supports `activerecord >= 5.0` and Rails 5.0 only supported `>= 2.2.2`.

This mean, no need to support Ruby 1.9 . So I think `encoding` magic comment is no need now.

FYI: Rails already removed this magic comment on Rails 5.0.
https://github.com/rails/rails/pull/24984