### PR TITLE
Use frozen string literals in migrations

### DIFF
--- a/lib/generators/data_migration/templates/data_migration.rb
+++ b/lib/generators/data_migration/templates/data_migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class <%= migration_class_name %> < <%= migration_base_class_name %>
   def up
   end


### PR DESCRIPTION
If you're in a project that uses a grumpy rubocop this is rather handy.