### PR TITLE
Removed schema dumper pragma

### DIFF
--- a/lib/data_migrate/schema_dumper.rb
+++ b/lib/data_migrate/schema_dumper.rb
@@ -17,12 +17,7 @@ module DataMigrate
     def dump(stream)
       define_params = @version ? "version: #{@version}" : ""
 
-      if stream.respond_to?(:external_encoding) && stream.external_encoding
-        stream.puts "# encoding: #{stream.external_encoding.name}"
-      end
-
       stream.puts "DataMigrate::Data.define(#{define_params})"
-
       stream
     end
 


### PR DESCRIPTION
## Overview

The pragma is unnecessary since it defaults to UTF-8 which is also
Ruby's default for all source files.

As an added benefit of removing this auto-generated pragma, fellow
engineers -- who use Rubocop -- will no longer encounter
`Style/Encoding` errors since this pragma would always be re-inserted
everytime `rake db:migrate:with_data` was run.

The corresponding spec doesn't need to be updated since it never
checked for the pragma to begin with.

## Details

Resolves Issue [195](https://github.com/ilyakatz/data-migrate/issues/195).

