### PR TITLE
Fixes #199 - Fixed class name in `DataMigrate::Migration.check_pending!` 

### DIFF
--- a/lib/data_migrate/migration.rb
+++ b/lib/data_migrate/migration.rb
@@ -3,7 +3,7 @@ module DataMigrate
 
     class << self
       def check_pending!(connection = ::ActiveRecord::Base.connection)
-        raise ActiveRecord::PendingMigrationError if DataMigrator::Migrator.needs_migration?(connection)
+        raise ActiveRecord::PendingMigrationError if DataMigrator::DataMigrator.needs_migration?(connection)
       end
 
       def migrate(direction)

--- a/lib/data_migrate/migration_five.rb
+++ b/lib/data_migrate/migration_five.rb
@@ -3,7 +3,7 @@ module DataMigrate
 
     class << self
       def check_pending!(connection = ::ActiveRecord::Base.connection)
-        raise ActiveRecord::PendingMigrationError if DataMigrator::Migrator.needs_migration?(connection)
+        raise ActiveRecord::PendingMigrationError if DataMigrator::DataMigrator.needs_migration?(connection)
       end
 
       def migrate(direction)


### PR DESCRIPTION
`DataMigrator::Migrator.needs_migration?` should be `DataMigrator::DataMigrator.needs_migration?`