### PR TITLE
Error with db:migrate:status:with_data and data:migrate:status

### DIFF
--- a/lib/data_migrate/schema_dumper.rb
+++ b/lib/data_migrate/schema_dumper.rb
@@ -8,7 +8,7 @@ module DataMigrate
     private_class_method :new
 
     class << self
-      def dump(connection = ActiveRecord::Base.connection, stream = STDOUT)
+      def dump(connection = ActiveRecord::Base.connection, stream = $stdout)
         new(connection).dump(stream)
         stream
       end

--- a/lib/data_migrate/status_service_five.rb
+++ b/lib/data_migrate/status_service_five.rb
@@ -1,7 +1,7 @@
 module DataMigrate
   class StatusService
     class << self
-      def dump(connection = ActiveRecord::Base.connection, stream = STDOUT)
+      def dump(connection = ActiveRecord::Base.connection, stream = $stdout)
         new(connection).dump(stream)
         stream
       end

--- a/lib/data_migrate/tasks/data_migrate_tasks.rb
+++ b/lib/data_migrate/tasks/data_migrate_tasks.rb
@@ -2,6 +2,11 @@ module DataMigrate
   module Tasks
     module DataMigrateTasks
       extend self
+
+      def schema_migrations_path
+        File.join('db', 'migrate')
+      end
+
       def migrations_paths
         @migrations_paths ||= DataMigrate.config.data_migrations_path
       end
@@ -39,6 +44,78 @@ module DataMigrate
         else
           ActiveRecord::Base.dump_schema_after_migration
         end
+      end
+
+      def status
+        config = connect_to_database
+        return unless config
+
+        connection = ActiveRecord::Base.connection
+        puts "\ndatabase: #{config['database']}\n\n"
+        DataMigrate::StatusService.dump(connection)
+      end
+
+      def status_with_schema
+        config = connect_to_database
+        return unless config
+
+        db_list_data = ActiveRecord::Base.connection.select_values(
+          "SELECT version FROM #{DataMigrate::DataSchemaMigration.table_name}"
+        )
+        db_list_schema = ActiveRecord::Base.connection.select_values(
+          "SELECT version FROM #{ActiveRecord::SchemaMigration.schema_migrations_table_name}"
+        )
+        file_list = []
+
+        Dir.foreach(File.join(Rails.root, migrations_paths)) do |file|
+          # only files matching "20091231235959_some_name.rb" pattern
+          if match_data = /(\d{14})_(.+)\.rb/.match(file)
+            status = db_list_data.delete(match_data[1]) ? 'up' : 'down'
+            file_list << [status, match_data[1], match_data[2], 'data']
+          end
+        end
+
+        Dir.foreach(File.join(Rails.root, schema_migrations_path)) do |file|
+          # only files matching "20091231235959_some_name.rb" pattern
+          if match_data = /(\d{14})_(.+)\.rb/.match(file)
+            status = db_list_schema.delete(match_data[1]) ? 'up' : 'down'
+            file_list << [status, match_data[1], match_data[2], 'schema']
+          end
+        end
+
+        file_list.sort!{|a,b| "#{a[1]}_#{a[3] == 'data' ? 1 : 0}" <=> "#{b[1]}_#{b[3] == 'data' ? 1 : 0}" }
+
+        # output
+        puts "\ndatabase: #{config['database']}\n\n"
+        puts "#{"Status".center(8)} #{"Type".center(8)}  #{"Migration ID".ljust(14)} Migration Name"
+        puts "-" * 60
+        file_list.each do |file|
+          puts "#{file[0].center(8)} #{file[3].center(8)} #{file[1].ljust(14)}  #{file[2].humanize}"
+        end
+        db_list_schema.each do |version|
+          puts "#{'up'.center(8)}  #{version.ljust(14)}  *** NO SCHEMA FILE ***"
+        end
+        db_list_data.each do |version|
+          puts "#{'up'.center(8)}  #{version.ljust(14)}  *** NO DATA FILE ***"
+        end
+        puts
+      end
+
+      private
+
+      def connect_to_database
+        config = ActiveRecord::Base.configurations[Rails.env || 'development']
+        ActiveRecord::Base.establish_connection(config)
+
+        unless DataMigrate::DataSchemaMigration.table_exists?
+          puts 'Data migrations table does not exist yet.'
+          config = nil
+        end
+        unless ActiveRecord::SchemaMigration.table_exists?
+          puts 'Schema migrations table does not exist yet.'
+          config = nil
+        end
+        config
       end
     end
   end

--- a/lib/data_migrate/tasks/data_migrate_tasks.rb
+++ b/lib/data_migrate/tasks/data_migrate_tasks.rb
@@ -104,7 +104,11 @@ module DataMigrate
       private
 
       def connect_to_database
-        config = ActiveRecord::Base.configurations[Rails.env || 'development']
+        config = if ActiveRecord.version < Gem::Version.new('6.1')
+          ActiveRecord::Base.configurations[Rails.env || 'development']
+        else
+          ActiveRecord::Base.configurations.find_db_config(Rails.env || 'development').configuration_hash
+        end
         ActiveRecord::Base.establish_connection(config)
 
         unless DataMigrate::DataSchemaMigration.table_exists?

--- a/spec/data_migrate/tasks/data_migrate_tasks_spec.rb
+++ b/spec/data_migrate/tasks/data_migrate_tasks_spec.rb
@@ -125,12 +125,12 @@ describe DataMigrate::Tasks::DataMigrateTasks do
     end
 
     before do
-      if Rails.version >= '6.1'
+      if Rails::VERSION::MAJOR == 5
+        ActiveRecord::Base.configurations['test'] = db_config
+      else
         hash_config = ActiveRecord::DatabaseConfigurations::HashConfig.new('test', 'test', db_config)
         config_obj = ActiveRecord::DatabaseConfigurations.new([hash_config])
         allow(ActiveRecord::Base).to receive(:configurations).and_return(config_obj)
-      else
-        ActiveRecord::Base.configurations[:test] = db_config
       end
 
       allow(Rails).to receive(:root) { '.' }


### PR DESCRIPTION
Hello,

I have the following error when trying to get status with the last version 8.0.0.rc1 and Rails 7.0
```
NoMethodError: undefined method `[]' for #<ActiveRecord::DatabaseConfigurations:0x000055a720dc5808 @configurations=[#<ActiveRecord::DatabaseConfigurations::UrlConfig:0x000055a720dc55d8 @env_name="default", @name="primary", @configuration_hash={:encoding=>"unicode", :pool=>5, :adapter=>"postgresql", :username=>"[...]", :database=>"[...]", :host=>"localhost"}, @url="postgres://[...]@localhost/[...]">, #<ActiveRecord::DatabaseConfigurations::UrlConfig:0x000055a720ddaff0 @env_name="development", @name="primary", @configuration_hash={:encoding=>"unicode", :pool=>5, :adapter=>"postgresql", :username=>"[...]", :database=>"[...]", :host=>"localhost"}, @url="postgres://[...]@localhost/[...]">, #<ActiveRecord::DatabaseConfigurations::UrlConfig:0x000055a720dd9588 @env_name="test", @name="primary", @configuration_hash={:encoding=>"unicode", :pool=>5, :adapter=>"postgresql", :username=>"[...]", :database=>"[...]", :host=>"localhost"}, @url="postgres://[...]@localhost/[...]">, #<ActiveRecord::DatabaseConfigurations::UrlConfig:0x000055a720de3b00 @env_name="production", @name="primary", @configuration_hash={:encoding=>"unicode", :pool=>5, :adapter=>"postgresql", :username=>"[...]", :database=>"[...]", :host=>"localhost"}, @url="postgres://[...]@localhost/[...]">]>
./vendor/bundle/ruby/3.0.0/gems/data_migrate-8.0.0.rc1/tasks/databases.rake:275:in `block (3 levels) in <top (required)>' 
```

This PR moves the code for both data:migrate:status and db:migrate:status:with_data in `DataMigrate::Tasks::DataMigrateTasks`, adds tests for those tasks and correct the bug for Rails 7.0.

@ilyakatz Does this look good to you ?