### PR TITLE
Add disable_ddl_transaction! to the migration template

### DIFF
--- a/lib/generators/data_migration/templates/data_migration.rb
+++ b/lib/generators/data_migration/templates/data_migration.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class <%= migration_class_name %> < <%= migration_base_class_name %>
+  disable_ddl_transaction!
+
   def up
   end
 


### PR DESCRIPTION
Most of the data migrations don't want to be wrapped in a transaction, the changes on each record normally should be applied immediately. It is easy to forget about the fact that every migration is wrapped within a transaction. And not it is simple to drop this statement if not needed in a particular case.