### PR TITLE
[FIX] Avoid Globally Accessible Functions for All Rake Tasks

### DIFF
--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -47,6 +47,40 @@ module DataMigrate
           Kernel.abort message
         end
       end
+
+      def pending_migrations
+        sort_migrations(
+          pending_schema_migrations,
+          pending_data_migrations
+        )
+      end
+
+      def sort_migrations set_1, set_2=nil
+        migrations = set_1 + (set_2 || [])
+        migrations.sort{|a,b|  sort_string(a) <=> sort_string(b)}
+      end
+
+      def sort_string migration
+        "#{migration[:version]}_#{migration[:kind] == :data ? 1 : 0}"
+      end
+
+      def data_migrations_path
+        ::DataMigrate.config.data_migrations_path
+      end
+
+      def run_migration(migration, direction)
+        if migration[:kind] == :data
+          ::ActiveRecord::Migration.write("== %s %s" % ['Data', "=" * 71])
+          ::DataMigrate::DataMigrator.run(direction, data_migrations_path, migration[:version])
+        else
+          ::ActiveRecord::Migration.write("== %s %s" % ['Schema', "=" * 69])
+          ::DataMigrate::SchemaMigration.run(
+            direction,
+            ::Continuation::SchemaMigration.migrations_paths,
+            migration[:version]
+          )
+        end
+      end
     end
 
     # This overrides ActiveRecord::Tasks::DatabaseTasks
@@ -121,6 +155,5 @@ module DataMigrate
 
       sort == "asc" ? sort_migrations(migrations) : sort_migrations(migrations).reverse
     end
-
   end
 end

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -4,29 +4,29 @@ namespace :db do
   namespace :migrate do
     desc "Migrate the database data and schema (options: VERSION=x, VERBOSE=false)."
     task :with_data => :environment do
-      assure_data_schema_table
+      DataMigrate::DataMigrator.assure_data_schema_table
 
       ActiveRecord::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
       target_version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
       migrations = []
 
       if target_version.nil?
-        migrations = pending_migrations.map{ |m| m.merge(:direction =>:up) }
+        migrations = DataMigrate::DatabaseTasks.pending_migrations.map{ |m| m.merge(:direction =>:up) }
       else
         current_schema_version = ActiveRecord::Migrator.current_version
         schema_migrations = if target_version > current_schema_version
-                              pending_schema_migrations.keep_if{ |m| m[:version] <= target_version }.map{ |m| m.merge(:direction =>:up) }
+                              DataMigrate::DatabaseTasks.pending_schema_migrations.keep_if{ |m| m[:version] <= target_version }.map{ |m| m.merge(:direction =>:up) }
                             elsif target_version < current_schema_version
-                              past_migrations.keep_if{ |m| m[:version] > target_version }.map{ |m| m.merge(:direction =>:down) }
+                              DataMigrate::DatabaseTasks.past_migrations.keep_if{ |m| m[:version] > target_version }.map{ |m| m.merge(:direction =>:down) }
                             else # ==
                               []
                             end
 
         current_data_version = ActiveRecord::Migrator.current_version
         data_migrations = if target_version > current_data_version
-                            pending_data_migrations.keep_if{ |m| m[:version] <= target_version }.map{ |m| m.merge(:direction =>:up) }
+                            DataMigrate::DatabaseTasks.pending_data_migrations.keep_if{ |m| m[:version] <= target_version }.map{ |m| m.merge(:direction =>:up) }
                           elsif target_version < current_data_version
-                            past_migrations.keep_if{ |m| m[:version] > target_version }.map{ |m| m.merge(:direction =>:down) }
+                            DataMigrate::DatabaseTasks.past_migrations.keep_if{ |m| m[:version] > target_version }.map{ |m| m.merge(:direction =>:down) }
                           else # ==
                             []
                           end
@@ -35,9 +35,9 @@ namespace :db do
                      elsif data_migrations.empty?
                        schema_migrations
                      elsif target_version > current_data_version && target_version > current_schema_version
-                       sort_migrations data_migrations, schema_migrations
+                       DataMigrate::DatabaseTasks.sort_migrations data_migrations, schema_migrations
                      elsif target_version < current_data_version && target_version < current_schema_version
-                       sort_migrations(data_migrations, schema_migrations).reverse
+                       DataMigrate::DatabaseTasks.sort_migrations(data_migrations, schema_migrations).reverse
                      elsif target_version > current_data_version && target_version < current_schema_version
                        schema_migrations + data_migrations
                      elsif target_version < current_data_version && target_version > current_schema_version
@@ -46,7 +46,7 @@ namespace :db do
       end
 
       migrations.each do |migration|
-        run_migration(migration, migration[:direction])
+        DataMigrate::DatabaseTasks.run_migration(migration, migration[:direction])
       end
 
       Rake::Task["db:_dump"].invoke
@@ -56,7 +56,7 @@ namespace :db do
     namespace :redo do
       desc 'Rollbacks the database one migration and re migrate up (options: STEP=x, VERSION=x).'
       task :with_data => :environment do
-      assure_data_schema_table
+      DataMigrate::DataMigrator.assure_data_schema_table
         if ENV["VERSION"]
           Rake::Task["db:migrate:down:with_data"].invoke
           Rake::Task["db:migrate:up:with_data"].invoke
@@ -72,16 +72,16 @@ namespace :db do
       task :with_data => :environment do
         version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
         raise "VERSION is required" unless version
-        assure_data_schema_table
+        DataMigrate::DataMigrator.assure_data_schema_table
         run_both = ENV["BOTH"] == "true"
-        migrations = pending_migrations.keep_if{|m| m[:version] == version}
+        migrations = DataMigrate::DatabaseTasks.pending_migrations.keep_if{|m| m[:version] == version}
 
         unless run_both || migrations.size < 2
           migrations = migrations.slice(0,1)
         end
 
         migrations.each do |migration|
-          run_migration(migration, :up)
+          DataMigrate::DatabaseTasks.run_migration(migration, :up)
         end
 
         Rake::Task["db:_dump"].invoke
@@ -94,16 +94,16 @@ namespace :db do
       task :with_data => :environment do
         version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
         raise "VERSION is required" unless version
-        assure_data_schema_table
+        DataMigrate::DataMigrator.assure_data_schema_table
         run_both = ENV["BOTH"] == "true"
-        migrations = past_migrations.keep_if{|m| m[:version] == version}
+        migrations = DataMigrate::DatabaseTasks.past_migrations.keep_if{|m| m[:version] == version}
 
         unless run_both || migrations.size < 2
           migrations = migrations.slice(0,1)
         end
 
         migrations.each do |migration|
-          run_migration(migration, :down)
+          DataMigrate::DatabaseTasks.run_migration(migration, :down)
         end
 
         Rake::Task["db:_dump"].invoke
@@ -123,9 +123,9 @@ namespace :db do
     desc 'Rolls the schema back to the previous version (specify steps w/ STEP=n).'
     task :with_data => :environment do
       step = ENV['STEP'] ? ENV['STEP'].to_i : 1
-      assure_data_schema_table
-      past_migrations[0..(step - 1)].each do | past_migration |
-        run_migration(past_migration, :down)
+      DataMigrate::DataMigrator.assure_data_schema_table
+      DataMigrate::DatabaseTasks.past_migrations[0..(step - 1)].each do | past_migration |
+        DataMigrate::DatabaseTasks.run_migration(past_migration, :down)
       end
 
       Rake::Task["db:_dump"].invoke
@@ -136,7 +136,7 @@ namespace :db do
   namespace :forward do
     desc 'Pushes the schema to the next version (specify steps w/ STEP=n).'
     task :with_data => :environment do
-      assure_data_schema_table
+      DataMigrate::DataMigrator.assure_data_schema_table
       step = ENV['STEP'] ? ENV['STEP'].to_i : 1
       DataMigrate::DatabaseTasks.forward(step)
       Rake::Task["db:_dump"].invoke
@@ -147,7 +147,7 @@ namespace :db do
   namespace :version do
     desc "Retrieves the current schema version numbers for data and schema migrations"
     task :with_data => :environment do
-      assure_data_schema_table
+      DataMigrate::DataMigrator.assure_data_schema_table
       puts "Current Schema version: #{ActiveRecord::Migrator.current_version}"
       puts "Current Data version: #{DataMigrate::DataMigrator.current_version}"
     end
@@ -157,7 +157,7 @@ namespace :db do
     desc "Raises an error if there are pending migrations or data migrations"
     task with_data: :environment do
       message = %{Run `rake db:migrate:with_data` to update your database then try again.}
-      DataMigrate::Tasks::DataMigrateTasks.abort_if_pending_migrations(pending_migrations, message)
+      DataMigrate::Tasks::DataMigrateTasks.abort_if_pending_migrations(DataMigrate::DatabaseTasks.pending_migrations, message)
     end
   end
 
@@ -200,7 +200,7 @@ namespace :data do
   namespace :migrate do
     desc  'Rollbacks the database one migration and re migrate up (options: STEP=x, VERSION=x).'
     task :redo => :environment do
-      assure_data_schema_table
+      DataMigrate::DataMigrator.assure_data_schema_table
       if ENV["VERSION"]
         Rake::Task["data:migrate:down"].invoke
         Rake::Task["data:migrate:up"].invoke
@@ -212,10 +212,10 @@ namespace :data do
 
     desc 'Runs the "up" for a given migration VERSION.'
     task :up => :environment do
-      assure_data_schema_table
+      DataMigrate::DataMigrator.assure_data_schema_table
       version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
       raise "VERSION is required" unless version
-      DataMigrate::DataMigrator.run(:up, data_migrations_path, version)
+      DataMigrate::DataMigrator.run(:up, DataMigrate::DatabaseTasks.data_migrations_path, version)
       Rake::Task["data:dump"].invoke
     end
 
@@ -223,8 +223,8 @@ namespace :data do
     task :down => :environment do
       version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
       raise "VERSION is required" unless version
-      assure_data_schema_table
-      DataMigrate::DataMigrator.run(:down, data_migrations_path, version)
+      DataMigrate::DataMigrator.assure_data_schema_table
+      DataMigrate::DataMigrator.run(:down, DataMigrate::DatabaseTasks.data_migrations_path, version)
       Rake::Task["data:dump"].invoke
     end
 
@@ -236,35 +236,35 @@ namespace :data do
 
   desc 'Rolls the schema back to the previous version (specify steps w/ STEP=n).'
   task :rollback => :environment do
-    assure_data_schema_table
+    DataMigrate::DataMigrator.assure_data_schema_table
     step = ENV['STEP'] ? ENV['STEP'].to_i : 1
-    DataMigrate::DataMigrator.rollback(data_migrations_path, step)
+    DataMigrate::DataMigrator.rollback(DataMigrate::DatabaseTasks.data_migrations_path, step)
     Rake::Task["data:dump"].invoke
   end
 
   desc 'Pushes the schema to the next version (specify steps w/ STEP=n).'
   task :forward => :environment do
-    assure_data_schema_table
+    DataMigrate::DataMigrator.assure_data_schema_table
     step = ENV['STEP'] ? ENV['STEP'].to_i : 1
     # TODO: No worky for .forward
     # DataMigrate::DataMigrator.forward('db/data/', step)
-    migrations = pending_data_migrations.reverse.pop(step).reverse
+    migrations = DataMigrate::DatabaseTasks.pending_data_migrations.reverse.pop(step).reverse
     migrations.each do | pending_migration |
-      DataMigrate::DataMigrator.run(:up, data_migrations_path, pending_migration[:version])
+      DataMigrate::DataMigrator.run(:up, DataMigrate::DatabaseTasks.data_migrations_path, pending_migration[:version])
     end
     Rake::Task["data:dump"].invoke
   end
 
   desc "Retrieves the current schema version number for data migrations"
   task :version => :environment do
-    assure_data_schema_table
+    DataMigrate::DataMigrator.assure_data_schema_table
     puts "Current data version: #{DataMigrate::DataMigrator.current_version}"
   end
 
   desc "Raises an error if there are pending data migrations"
   task abort_if_pending_migrations: :environment do
     message = %{Run `rake data:migrate` to update your database then try again.}
-    DataMigrate::Tasks::DataMigrateTasks.abort_if_pending_migrations(pending_data_migrations, message)
+    DataMigrate::Tasks::DataMigrateTasks.abort_if_pending_migrations(DataMigrate::DatabaseTasks.pending_data_migrations, message)
   end
 
   desc "Create a db/data_schema.rb file that stores the current data version"
@@ -285,55 +285,5 @@ namespace :data do
         ENV["DATA_SCHEMA"]
       )
     end
-  end
-end
-
-def pending_migrations
-  DataMigrate::DatabaseTasks.sort_migrations(
-    DataMigrate::DatabaseTasks.pending_schema_migrations,
-    DataMigrate::DatabaseTasks.pending_data_migrations
-  )
-end
-
-def pending_data_migrations
-  DataMigrate::DatabaseTasks.pending_data_migrations
-end
-
-def pending_schema_migrations
-  DataMigrate::DatabaseTasks.pending_schema_migrations
-end
-
-def sort_migrations set_1, set_2=nil
-  migrations = set_1 + (set_2 || [])
-  migrations.sort{|a,b|  sort_string(a) <=> sort_string(b)}
-end
-
-def sort_string migration
-  "#{migration[:version]}_#{migration[:kind] == :data ? 1 : 0}"
-end
-
-def past_migrations(sort=nil)
-  DataMigrate::DatabaseTasks.past_migrations(sort)
-end
-
-def assure_data_schema_table
-  DataMigrate::DataMigrator.assure_data_schema_table
-end
-
-def data_migrations_path
-  DataMigrate.config.data_migrations_path
-end
-
-def run_migration(migration, direction)
-  if migration[:kind] == :data
-    ActiveRecord::Migration.write("== %s %s" % ['Data', "=" * 71])
-    DataMigrate::DataMigrator.run(direction, data_migrations_path, migration[:version])
-  else
-    ActiveRecord::Migration.write("== %s %s" % ['Schema', "=" * 69])
-    DataMigrate::SchemaMigration.run(
-      direction,
-      DataMigrate::SchemaMigration.migrations_paths,
-      migration[:version]
-    )
   end
 end


### PR DESCRIPTION
## Description

Functions defined in rake tasks are globally accessible when executing any rake task. The gotcha here is that the defined methods in the loaded tasks files end up defined on the global namespace. These defined methods are therefore accessible across rake files, so it is possible for methods to clash and be redefined if signatures match.

REF: https://kevinjalbert.com/defined_methods-in-rake-tasks-you-re-gonna-have-a-bad-time/

## Screenshots

Here's our rake tasks defined in our own scope but still accessible to `data_migrate`'s rake functions
<img width="686" alt="Screen Shot 2022-02-27 at 3 17 51" src="https://user-images.githubusercontent.com/2749593/155873562-254371de-b35e-4922-b8f2-71167ba17882.png">