### PR TITLE
Delegate to anonymous subclass of AR::SchemaMigration

### DIFF
--- a/lib/data_migrate/data_schema_migration.rb
+++ b/lib/data_migrate/data_schema_migration.rb
@@ -1,15 +1,14 @@
 module DataMigrate
-  class DataSchemaMigration < ::ActiveRecord::SchemaMigration
-
+  class DataSchemaMigration
     class << self
-      def table_name
-        ActiveRecord::Base.table_name_prefix + 'data_migrations' + ActiveRecord::Base.table_name_suffix
-      end
+      delegate :table_name, :primary_key, :create_table, :normalized_versions, :create, :create!, :table_exists?, :where, to: :instance
 
-      def primary_key
-        "version"
+      def instance
+        @instance ||= Class.new(::ActiveRecord::SchemaMigration) do
+          define_singleton_method(:table_name) { ActiveRecord::Base.table_name_prefix + 'data_migrations' + ActiveRecord::Base.table_name_suffix }
+          define_singleton_method(:primary_key) { "version" }
+        end
       end
     end
   end
 end
-


### PR DESCRIPTION
I've found that adding the `data_migrate` gem will cause a database connection to be forced when running `rails assets:precompile` and was able to pin down the problem to the subclassing of `ActiveRecord::SchemaMigration` to create `DataMigrate::DataSchemaMigration`

Of course, there are workarounds like adding a `nulldb` adapter to make `assets:precompile` work in this situation, but I feel like a dependency should not force us to do this if at all possible.  

Using composition in favour of inheritance and delegating to the instance does seem to fix the problem here, though there might be other ways to achieve this (e.g. deferred requiring of `data_migrate/data_schema_migration`)

[This example app](https://github.com/foxondo/data-migrate-bug) showcases the issue. 
