### PR TITLE
Fix generation when engines define data migrations path

### DIFF
--- a/lib/data_migrate/config.rb
+++ b/lib/data_migrate/config.rb
@@ -12,10 +12,11 @@ module DataMigrate
   end
 
   class Config
-    attr_accessor :data_migrations_path, :db_configuration, :spec_name
+    attr_accessor :data_migrations_gen_path, :data_migrations_path, :db_configuration, :spec_name
 
     def initialize
       @data_migrations_path = "db/data/"
+      @data_migrations_gen_path = "db/data/"
       @db_configuration = nil
       @spec_name = nil
     end

--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -35,7 +35,7 @@ module DataMigrate
       end
 
       def data_migrations_path
-        DataMigrate.config.data_migrations_path
+        DataMigrate.config.data_migrations_gen_path || DataMigrate.config.data_migrations_path
       end
     end
   end


### PR DESCRIPTION
Hey there!

There is a bug when having multiple paths defined by engines:

Let's say we have some engines at the `engines` folder
If any engine add a data migration path, when generating a new data migration with `rails g data_migration Something` then it'll join all paths into a monstrosity like `db/data/User/MyUser/path/to/project/engines/engineA/db/data/User/....`


This PR adds a new config option which is pretty much similar to the old `data_migrations_path`, except that it is only for setting the generation folder, so while multiple engines might add migrations path, only one migration gen path will exist