### PR TITLE
Add delegation to exists? for use by third parties

### DIFF
--- a/lib/data_migrate/data_schema_migration.rb
+++ b/lib/data_migrate/data_schema_migration.rb
@@ -1,7 +1,7 @@
 module DataMigrate
   class DataSchemaMigration
     class << self
-      delegate :table_name, :primary_key, :create_table, :normalized_versions, :create, :create!, :table_exists?, :where, to: :instance
+      delegate :table_name, :primary_key, :create_table, :normalized_versions, :create, :create!, :table_exists?, :exists?, :where, to: :instance
 
       def instance
         @instance ||= Class.new(::ActiveRecord::SchemaMigration) do


### PR DESCRIPTION
As of 8.2.0 `DataSchemaMigration` will not expose all inherited methods from Active Record any longer, but only ones needed by the gem internally.

It seems to make sense to provide `exists?` to 3rd parties although it does not seem to be explicitly needed.

Fixes #230 