### PR TITLE
[#224] Support custom data migration template

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ You can override this setting in `config/initializers/data_migrate.rb`
 ```ruby
 DataMigrate.configure do |config|
   config.data_migrations_path = 'db/awesomepath/'
+  config.data_template_path = Rails.root.join("lib", "awesomepath", "custom_data_migration.rb")
   config.db_configuration = {
     'host' => '127.0.0.1',
     'database' => 'awesome_database',

--- a/lib/data_migrate.rb
+++ b/lib/data_migrate.rb
@@ -20,6 +20,6 @@ end
 
 module DataMigrate
   def self.root
-    File.dirname(__dir__)
+    File.dirname(__FILE__)
   end
 end

--- a/lib/data_migrate.rb
+++ b/lib/data_migrate.rb
@@ -19,4 +19,7 @@ else
 end
 
 module DataMigrate
+  def self.root
+    File.dirname(__dir__)
+  end
 end

--- a/lib/data_migrate/config.rb
+++ b/lib/data_migrate/config.rb
@@ -22,5 +22,11 @@ module DataMigrate
       @db_configuration = nil
       @spec_name = nil
     end
+
+    def data_template_path=(value)
+      @data_template_path = value.tap do |path|
+        raise ArgumentError, "File not found: '#{path}'" unless path == DEFAULT_DATA_TEMPLATE_PATH || File.exists?(path)
+      end
+    end
   end
 end

--- a/lib/data_migrate/config.rb
+++ b/lib/data_migrate/config.rb
@@ -12,10 +12,13 @@ module DataMigrate
   end
 
   class Config
-    attr_accessor :data_migrations_path, :db_configuration, :spec_name
+    attr_accessor :data_migrations_path, :data_template_path, :db_configuration, :spec_name
+
+    DEFAULT_DATA_TEMPLATE_PATH = "data_migration.rb"
 
     def initialize
       @data_migrations_path = "db/data/"
+      @data_template_path = DEFAULT_DATA_TEMPLATE_PATH
       @db_configuration = nil
       @spec_name = nil
     end

--- a/lib/generators/data_migrate.rb
+++ b/lib/generators/data_migrate.rb
@@ -1,9 +1,22 @@
 require 'rails/generators/named_base'
+
 module DataMigrate
   module Generators
     class DataMigrationGenerator < Rails::Generators::NamedBase #:nodoc:
-      def self.source_root
-         @_data_migrate_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), generator_name, 'templates'))
+      class << self
+        def source_root
+          build_data_migrate_source_root
+        end
+
+        private
+
+        def build_data_migrate_source_root
+          if DataMigrate.config.data_template_path == DataMigrate::Config::DEFAULT_DATA_TEMPLATE_PATH
+            File.expand_path(File.join(File.dirname(__FILE__), generator_name, 'templates'))
+          else
+            File.expand_path(File.dirname(DataMigrate.config.data_template_path))
+          end
+        end
       end
     end
   end

--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -14,7 +14,7 @@ module DataMigrate
 
       def create_data_migration
         set_local_assigns!
-        migration_template "data_migration.rb", data_migrations_file_path
+        migration_template template_path, data_migrations_file_path
       end
 
       protected
@@ -24,6 +24,10 @@ module DataMigrate
           @migration_action = $1
           @table_name       = $2.pluralize
         end
+      end
+
+      def template_path
+        DataMigrate.config.data_template_path
       end
 
       def migration_base_class_name

--- a/spec/data_migrate/config_spec.rb
+++ b/spec/data_migrate/config_spec.rb
@@ -39,7 +39,9 @@ describe DataMigrate::Config do
       end
     end
 
-    let(:data_template_path) { "lib/awesome/templates/data_migration.rb" }
+    let(:data_template_path) do
+      File.join(DataMigrate.root, "generators", "data_migration", "templates", "data_migration.rb")
+    end
 
     after do
       DataMigrate.configure do |config|
@@ -49,6 +51,16 @@ describe DataMigrate::Config do
 
     it "equals the custom data template path" do
       is_expected.to eq data_template_path
+    end
+
+    context "when path does not exist" do
+      subject { DataMigrate.config.data_template_path = invalid_path }
+
+      let(:invalid_path) { "lib/awesome/templates/data_migration.rb" }
+
+      it "checks that file exists on setting config var" do
+        expect { subject }.to raise_error { ArgumentError.new("File not found: '#{data_template_path}'") }
+      end
     end
   end
 end

--- a/spec/data_migrate/config_spec.rb
+++ b/spec/data_migrate/config_spec.rb
@@ -1,12 +1,16 @@
 require "spec_helper"
 
 describe DataMigrate::Config do
-
   it "sets default data_migrations_path path", :no_override do
     expect(DataMigrate.config.data_migrations_path).to eq "db/data/"
   end
 
+  it "sets default data_template_path path", :no_override do
+    expect(DataMigrate.config.data_template_path).to eq DataMigrate::Config::DEFAULT_DATA_TEMPLATE_PATH
+  end
+
   describe "data migration path configured" do
+    subject { DataMigrate.config.data_migrations_path }
     before do
       @before = DataMigrate.config.data_migrations_path
       DataMigrate.configure do |config|
@@ -20,8 +24,31 @@ describe DataMigrate::Config do
       end
     end
 
-    it do
-      expect(DataMigrate.config.data_migrations_path).to eq "db/awesome/"
+    it "equals the custom data migration path" do
+      is_expected.to eq "db/awesome/"
+    end
+  end
+
+  describe "data template path configured" do
+    subject { DataMigrate.config.data_template_path }
+
+    before do
+      @before = DataMigrate.config.data_template_path
+      DataMigrate.configure do |config|
+        config.data_template_path = data_template_path
+      end
+    end
+
+    let(:data_template_path) { "lib/awesome/templates/data_migration.rb" }
+
+    after do
+      DataMigrate.configure do |config|
+        config.data_template_path = @before
+      end
+    end
+
+    it "equals the custom data template path" do
+      is_expected.to eq data_template_path
     end
   end
 end

--- a/spec/generators/data_migration/data_migration_generator_spec.rb
+++ b/spec/generators/data_migration/data_migration_generator_spec.rb
@@ -68,7 +68,7 @@ describe DataMigrate::Generators::DataMigrationGenerator do
 
     let(:default_source_root) do
       File.expand_path(
-        File.dirname(File.join(DataMigrate.root, "lib", "generators", "data_migration", "templates", "data_migration.rb"))
+        File.dirname(File.join(DataMigrate.root, "generators", "data_migration", "templates", "data_migration.rb"))
       )
     end
 
@@ -82,8 +82,10 @@ describe DataMigrate::Generators::DataMigrationGenerator do
         end
       end
 
-      let(:data_template_path) { "lib/awesome/templates/data_migration.rb" }
-      let(:expected_source_root) { File.expand_path(File.dirname(File.join(DataMigrate.root, data_template_path))) }
+      let(:data_template_path) do
+        File.join(DataMigrate.root, "generators", "data_migration", "templates", "data_migration.rb")
+      end
+      let(:expected_source_root) { File.dirname(data_template_path) }
 
       after do
         DataMigrate.configure do |config|

--- a/spec/generators/data_migration/data_migration_generator_spec.rb
+++ b/spec/generators/data_migration/data_migration_generator_spec.rb
@@ -68,7 +68,7 @@ describe DataMigrate::Generators::DataMigrationGenerator do
 
     let(:default_source_root) do
       File.expand_path(
-        File.dirname(Bundler.root.join("lib", "generators", "data_migration", "templates", "data_migration.rb"))
+        File.dirname(File.join(DataMigrate.root, "lib", "generators", "data_migration", "templates", "data_migration.rb"))
       )
     end
 
@@ -83,7 +83,7 @@ describe DataMigrate::Generators::DataMigrationGenerator do
       end
 
       let(:data_template_path) { "lib/awesome/templates/data_migration.rb" }
-      let(:expected_source_root) { File.expand_path(File.dirname(Bundler.root.join(data_template_path))) }
+      let(:expected_source_root) { File.expand_path(File.dirname(File.join(DataMigrate.root, data_template_path))) }
 
       after do
         DataMigrate.configure do |config|


### PR DESCRIPTION
Implements feature request in issue: https://github.com/ilyakatz/data-migrate/issues/224

## Todo
- [x] Test feature from Rails app

## Testing Notes
The following code snippets are taken from a personal Rails application using this feature branch as gem source.

**config/initializers/data_migrate.rb**
```ruby
DataMigrate.configure do |config|
  config.data_migrations_path = "db/maintenance/"
  config.data_template_path = Rails.root.join("lib/maintenance/maintenance_migration_template.rb")
end
```
**lib/maintenance/maintenance_migration_template.rb**
```ruby
# frozen_string_literal: true

class <%= migration_class_name %> < <%= migration_base_class_name %>
  def up
    # Call you migration task from here
    #
    # For example:
    # params = {
    #   key: "value",
    # }
    #
    # Maintenance::MyTask.perform_later(**params)
  end

  def down
    raise ActiveRecord::IrreversibleMigration
  end
end
```
Running the generator:
```bash
$ bin/rails g data_migration MaintenanceTest                                                                                                                                                     add-data-migrate
      create  db/maintenance/20221121162436_maintenance_test.rb
```
where
**db/maintenance/20221121162436_maintenance_test.rb**
contains
```ruby
class MaintenanceTest < ActiveRecord::Migration[7.0]
  def up
    # Call you migration task from here
    #
    # For example:
    # params = {
    #   key: "value",
    # }
    #
    # Maintenance::MyTask.perform_later(**params)
  end

  def down
    raise ActiveRecord::IrreversibleMigration
  end
end
```
I can also confirm that removing `config.data_template_path` from `config/initializers/data_migrate.rb` will use the [default template](https://github.com/ilyakatz/data-migrate/blob/master/lib/generators/data_migration/templates/data_migration.rb).