### PR TITLE
Fix current data version lookup in db:migrate:with_data

### DIFF
--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -22,7 +22,7 @@ namespace :db do
                               []
                             end
 
-        current_data_version = ActiveRecord::Migrator.current_version
+        current_data_version = DataMigrate::DataMigrator.current_version
         data_migrations = if target_version > current_data_version
                             DataMigrate::DatabaseTasks.pending_data_migrations.keep_if{ |m| m[:version] <= target_version }.map{ |m| m.merge(:direction =>:up) }
                           elsif target_version < current_data_version


### PR DESCRIPTION
This is a re-creation of #202, which fixes a bug where the AR migration schema version is incorrectly referenced instead of the data migration version.

This causes data migrations be to be incorrectly re-run on an otherwise migrated database whenever the most recent schema version is lower than the most recent data version.