### PR TITLE
temp(rails): initiate rails 7.1 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ spec/db/data_schema.rb
 .DS_Store
 .idea/
 vendor/
+/.tool-versions

--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,3 @@
-appraise 'rails-5.2' do
-  gem 'rails', '~> 5.2.3'
-end
-
 appraise 'rails-6.0' do
   gem 'rails', '~> 6.0.0'
 end
@@ -12,4 +8,8 @@ end
 
 appraise 'rails-7.0' do
   gem 'rails', '~> 7.0'
+end
+
+appraise 'rails-7.1' do
+  gem 'rails', git: "https://github.com/rails/rails.git", branch: "main"
 end

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -2,7 +2,7 @@
 
 source "http://rubygems.org"
 
-gem "rails", "~> 6.0.0"
 gem "sqlite3", "~> 1.4"
+gem "rails", "~> 6.0.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -2,7 +2,7 @@
 
 source "http://rubygems.org"
 
-gem "rails", "~> 6.1.0"
 gem "sqlite3", "~> 1.4"
+gem "rails", "~> 6.1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -2,7 +2,7 @@
 
 source "http://rubygems.org"
 
-gem "rails", "~> 5.2.3"
 gem "sqlite3", "~> 1.4"
+gem "rails", git: "https://github.com/rails/rails.git", branch: "main"
 
 gemspec path: "../"

--- a/lib/data_migrate/data_migrator_five.rb
+++ b/lib/data_migrate/data_migrator_five.rb
@@ -23,7 +23,7 @@ module DataMigrate
       validate(@migrations)
 
       DataMigrate::DataSchemaMigration.create_table
-      ActiveRecord::InternalMetadata.create_table
+      ActiveRecord::Base.connection.internal_metadata.create_table
     end
 
     def load_migrated

--- a/lib/data_migrate/data_schema_migration.rb
+++ b/lib/data_migrate/data_schema_migration.rb
@@ -4,9 +4,14 @@ module DataMigrate
       delegate :table_name, :primary_key, :create_table, :normalized_versions, :create, :create!, :table_exists?, :exists?, :where, to: :instance
 
       def instance
-        @instance ||= Class.new(::ActiveRecord::SchemaMigration) do
-          define_singleton_method(:table_name) { ActiveRecord::Base.table_name_prefix + 'data_migrations' + ActiveRecord::Base.table_name_suffix }
-          define_singleton_method(:primary_key) { "version" }
+        @instance ||= begin 
+          instance = ActiveRecord::Base.connection.schema_migration
+          instance.instance_exec do 
+            define_singleton_method(:table_name) { ActiveRecord::Base.table_name_prefix + 'data_migrations' + ActiveRecord::Base.table_name_suffix }
+            define_singleton_method(:primary_key) { "version" }
+          end
+
+          instance
         end
       end
     end

--- a/lib/data_migrate/schema_migration_six.rb
+++ b/lib/data_migrate/schema_migration_six.rb
@@ -3,7 +3,7 @@ module DataMigrate
   # to allow data/schema combiation tasks
   class SchemaMigration
     def self.pending_schema_migrations
-      all_migrations = DataMigrate::MigrationContext.new(migrations_paths).migrations
+      all_migrations = DataMigrate::MigrationContext.new(migrations_paths, ActiveRecord::Base.connection.schema_migration).migrations
       sort_migrations(
         ActiveRecord::Migrator.new(:up, all_migrations, ActiveRecord::Base.connection.schema_migration).
         pending_migrations.

--- a/spec/data_migrate/data_migrator_spec.rb
+++ b/spec/data_migrate/data_migrator_spec.rb
@@ -18,7 +18,7 @@ describe DataMigrate::DataMigrator do
     before do
       allow(subject).to receive(:db_config) { db_config }.at_least(:once)
       ActiveRecord::Base.establish_connection(db_config)
-      ::ActiveRecord::SchemaMigration.create_table
+      ::ActiveRecord::Base.connection.schema_migration.create_table
       DataMigrate::DataSchemaMigration.create_table
     end
 
@@ -63,7 +63,7 @@ describe DataMigrate::DataMigrator do
     before do
       allow(subject).to receive(:db_config) { db_config }.at_least(:once)
       ActiveRecord::Base.establish_connection(db_config)
-      ::ActiveRecord::SchemaMigration.create_table
+      ::ActiveRecord::Base.connection.schema_migration.create_table
       DataMigrate::DataSchemaMigration.create_table
     end
 

--- a/spec/data_migrate/database_tasks_spec.rb
+++ b/spec/data_migrate/database_tasks_spec.rb
@@ -60,7 +60,7 @@ describe DataMigrate::DatabaseTasks do
     end
 
     before do
-      ActiveRecord::SchemaMigration.create_table
+      ActiveRecord::Base.connection.schema_migration.create_table
 
       allow(DataMigrate::SchemaMigration).to receive(:migrations_paths) {
         migration_path

--- a/spec/data_migrate/legacy_migrator_spec.rb
+++ b/spec/data_migrate/legacy_migrator_spec.rb
@@ -16,7 +16,7 @@ describe DataMigrate::LegacyMigrator do
 
   before do
     ActiveRecord::Base.establish_connection(db_config)
-    ActiveRecord::SchemaMigration.create_table
+    ActiveRecord::Base.connection.schema_migration.create_table
     DataMigrate::DataSchemaMigration.create_table
   end
 

--- a/spec/data_migrate/migration_context_spec.rb
+++ b/spec/data_migrate/migration_context_spec.rb
@@ -35,7 +35,7 @@ describe DataMigrate::DataMigrator do
   describe :migrate do
     before do
       ActiveRecord::Base.establish_connection(db_config)
-      ActiveRecord::SchemaMigration.create_table
+      ActiveRecord::Base.connection.schema_migration.create_table
     end
 
     after do

--- a/spec/data_migrate/schema_dumper_spec.rb
+++ b/spec/data_migrate/schema_dumper_spec.rb
@@ -20,7 +20,7 @@ describe DataMigrate::SchemaDumper do
         to receive(:db_config) { db_config }.at_least(:once)
       ActiveRecord::Base.establish_connection(db_config)
 
-      ActiveRecord::SchemaMigration.create_table
+      ActiveRecord::Base.connection.schema_migration.create_table
       DataMigrate::DataMigrator.assure_data_schema_table
 
       ActiveRecord::Base.connection.execute <<-SQL

--- a/spec/data_migrate/schema_migration_spec.rb
+++ b/spec/data_migrate/schema_migration_spec.rb
@@ -24,7 +24,7 @@ describe DataMigrate::SchemaMigration do
 
   before do
     ActiveRecord::Base.establish_connection(db_config)
-    ActiveRecord::SchemaMigration.create_table
+    ActiveRecord::Base.connection.schema_migration.create_table
   end
 
   after do

--- a/spec/data_migrate/status_service_spec.rb
+++ b/spec/data_migrate/status_service_spec.rb
@@ -38,7 +38,7 @@ describe DataMigrate::StatusService do
         to receive(:db_config) { db_config }.at_least(:once)
       ActiveRecord::Base.establish_connection(db_config)
 
-      ActiveRecord::SchemaMigration.create_table
+      ActiveRecord::Base.connection.schema_migration.create_table
       DataMigrate::DataMigrator.assure_data_schema_table
 
       ActiveRecord::Base.connection.execute <<-SQL


### PR DESCRIPTION
I'm not sure I'll be able to pull this off. They changed too much in rails 7.1 and I'm not familiar enough with the rails code base to finish this. 

That said, unless someone can pick it up I will continue hacking away at it. 

One issue that I immediately noticed is with the `ActiveRecord::Migrator` class that now looks like:

```ruby
    def initialize(direction, migrations, schema_migration, internal_metadata, target_version = nil)
      @direction         = direction
      @target_version    = target_version
      @migrated_versions = nil
      @migrations        = migrations
      @schema_migration  = schema_migration
      @internal_metadata = internal_metadata

      validate(@migrations)

      @schema_migration.create_table
      @internal_metadata.create_table
    end
```

I am unable to make decisions on which direction to take this. Like, how would we keep this backward compatible?

Relates to #241 

@ilyakatz how do we proceed?