### PR TITLE
Reset column information in-between each migration

### DIFF
--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -69,6 +69,8 @@ module DataMigrate
       end
 
       def run_migration(migration, direction)
+        ActiveRecord::Base.descendants.each(&:reset_column_information)
+
         if migration[:kind] == :data
           ::ActiveRecord::Migration.write("== %s %s" % ['Data', "=" * 71])
           ::DataMigrate::DataMigrator.run(direction, data_migrations_path, migration[:version])
@@ -92,6 +94,8 @@ module DataMigrate
       DataMigrate::DataMigrator.assure_data_schema_table
       migrations = pending_migrations.reverse.pop(step).reverse
       migrations.each do | pending_migration |
+        ActiveRecord::Base.descendants.each(&:reset_column_information)
+
         if pending_migration[:kind] == :data
           ActiveRecord::Migration.write("== %s %s" % ["Data", "=" * 71])
           DataMigrate::DataMigrator.run(:up, data_migrations_path, pending_migration[:version])


### PR DESCRIPTION
We ran into an issue where having the following run in the same `rake db:migrate:with_data` process caused an issue:

1. Data migration that writes to a table
2. Schema migration that adds a new column to the table
3. Data migration that writes to the same table

We ended up needing to call `ActiveRecord::Base#reset_column_information)` as documented in the rails guides between amending the table and trying to write to it in the same ruby process. (If you split any of the above migration files into different runs, this issue goes away.)

Rather than have to remember to call reset_column_information every time we either amend a table or try to write to a table in either schema or data migrations respectively, lets just call it for all models before we run either migration. It's a very low cost call from testing and migrations aren't usually run all that often (certainly compared to web requests).