### PR TITLE
Remove iteration over multiple databases

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,20 +1,20 @@
 # Changelog
 
-## 10.0.3.rc
+## [YANKED] 10.0.3.rc
 
 - Remove all travis references [leoarnold](https//:github.com/leoarnold)
 - Changing to rc because of ongoing discussion how to properly handle multiple database environments
 
-## 10.0.2
+## [YANKED] 10.0.2
 
 Change "rails" dependencies to "railties"
 
-## 10.0.1
+## [YANKED] 10.0.1
 
 - Bug fix for Rails 6 config [chaunce](https//:github.com/chaunce)
 - Railties bug fix by [opti](https://github.com/opti)
 
-## 10.0.0
+## [YANKED] 10.0.0
 
 Releasing 10.0.0
 
@@ -23,13 +23,12 @@ Releasing 10.0.0
 - This version introduces a breaking change which may lead to undesired
 behavior in multi-database environments. See https://github.com/ilyakatz/data-migrate/issues/181
 
-## 10.0.0.rc1
+## [YANKED] 10.0.0.rc1
 
 - Changes by [chaunce](https//:github.com/chaunce)
 - Multiple databases support
 - Refactor to clean things up
 - Deprecate rails 5.2 support for real
-
 
 ## 9.0.0
 

--- a/lib/data_migrate/data_migrator.rb
+++ b/lib/data_migrate/data_migrator.rb
@@ -9,7 +9,7 @@ module DataMigrate
       [DataMigrate.config.data_migrations_path]
     end
 
-    def self.assure_data_schema_table
+    def self.create_data_schema_table
       DataMigrate::DataSchemaMigration.create_table
     end
 

--- a/lib/data_migrate/data_schema.rb
+++ b/lib/data_migrate/data_schema.rb
@@ -9,7 +9,7 @@ module DataMigrate
     #   ActiveRecord::ConnectionAdapters::SchemaStatements
     #     #assume_migrated_upto_version
     def define(info)
-      DataMigrate::DataMigrator.assure_data_schema_table
+      DataMigrate::DataMigrator.create_data_schema_table
 
       return if info[:version].blank?
 

--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -9,6 +9,10 @@ module DataMigrate
     extend ActiveRecord::Tasks::DatabaseTasks
 
     class << self
+      def schema_file(_format = nil)
+        File.join(db_dir, "data_schema.rb")
+      end
+
       def schema_file_type(_format = nil)
         "data_schema.rb"
       end

--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -69,7 +69,7 @@ module DataMigrate
     end
 
     def self.forward(step = 1)
-      DataMigrate::DataMigrator.assure_data_schema_table
+      DataMigrate::DataMigrator.create_data_schema_table
       migrations = pending_migrations.reverse.pop(step).reverse
       migrations.each do | pending_migration |
         if pending_migration[:kind] == :data

--- a/lib/data_migrate/tasks/data_migrate_tasks.rb
+++ b/lib/data_migrate/tasks/data_migrate_tasks.rb
@@ -22,7 +22,7 @@ module DataMigrate
       def migrate
         target_version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
 
-        DataMigrate::DataMigrator.assure_data_schema_table
+        DataMigrate::DataMigrator.create_data_schema_table
         DataMigrate::MigrationContext.new(migrations_paths).migrate(target_version)
       end
 

--- a/lib/data_migrate/tasks/data_migrate_tasks.rb
+++ b/lib/data_migrate/tasks/data_migrate_tasks.rb
@@ -44,12 +44,11 @@ module DataMigrate
         end
       end
 
-      def status(db_config)
-        puts "\ndatabase: #{spec_name(db_config)}\n\n"
-        DataMigrate::StatusService.dump(ActiveRecord::Base.connection)
+      def status
+        DataMigrate::StatusService.dump
       end
 
-      def status_with_schema(db_config)
+      def status_with_schema
         db_list_data = ActiveRecord::Base.connection.select_values(
           "SELECT version FROM #{DataMigrate::DataSchemaMigration.table_name}"
         )
@@ -77,7 +76,7 @@ module DataMigrate
         file_list.sort!{|a,b| "#{a[1]}_#{a[3] == 'data' ? 1 : 0}" <=> "#{b[1]}_#{b[3] == 'data' ? 1 : 0}" }
 
         # output
-        puts "\ndatabase: #{spec_name(db_config)}\n\n"
+        puts "\ndatabase: #{database_name}\n\n"
         puts "#{"Status".center(8)} #{"Type".center(8)}  #{"Migration ID".ljust(14)} Migration Name"
         puts "-" * 60
         file_list.each do |file|
@@ -94,11 +93,11 @@ module DataMigrate
 
       private
 
-      def spec_name(db_config)
+      def database_name
         if Gem::Dependency.new("railties", "~> 7.0").match?("railties", Gem.loaded_specs["railties"].version)
-          db_config.name
+          ActiveRecord::Base.connection_db_config.database
         elsif Gem::Dependency.new("railties", "~> 6.0").match?("railties", Gem.loaded_specs["railties"].version)
-          db_config.spec_name
+          ActiveRecord::Base.connection_config[:database]
         end
       end
     end

--- a/lib/data_migrate/tasks/data_migrate_tasks.rb
+++ b/lib/data_migrate/tasks/data_migrate_tasks.rb
@@ -9,9 +9,9 @@ module DataMigrate
         @migrations_paths ||= DataMigrate.config.data_migrations_path
       end
 
-      def dump(db_config)
+      def dump
         if dump_schema_after_migration?
-          filename = DataMigrate::DatabaseTasks.dump_filename(spec_name(db_config), ActiveRecord::Base.schema_format)
+          filename = DataMigrate::DatabaseTasks.schema_file
           ActiveRecord::Base.establish_connection(DataMigrate.config.db_configuration) if DataMigrate.config.db_configuration
           File.open(filename, "w:utf-8") do |file|
             DataMigrate::SchemaDumper.dump(ActiveRecord::Base.connection, file)

--- a/spec/data_migrate/data_migrator_spec.rb
+++ b/spec/data_migrate/data_migrator_spec.rb
@@ -35,10 +35,10 @@ describe DataMigrate::DataMigrator do
     end
   end
 
-  describe :assure_data_schema_table do
+  describe :create_data_schema_table do
     it "creates the data_migrations table" do
       ActiveRecord::Migration.drop_table("data_migrations") rescue nil
-      subject.assure_data_schema_table
+      subject.create_data_schema_table
       expect(
         ActiveRecord::Base.connection.table_exists?("data_migrations")
       ).to eq true

--- a/spec/data_migrate/tasks/data_migrate_tasks_spec.rb
+++ b/spec/data_migrate/tasks/data_migrate_tasks_spec.rb
@@ -28,11 +28,11 @@ describe DataMigrate::Tasks::DataMigrateTasks do
     end
 
     context 'when not given a separate db config' do
-      it 'does not override the default connection' do  
+      it 'does not override the default connection' do
         expect(ActiveRecord::Base).not_to receive(:establish_connection)
         expect(DataMigrate::SchemaDumper).to receive(:dump)
 
-        DataMigrate::Tasks::DataMigrateTasks.dump(connection_db_config)
+        DataMigrate::Tasks::DataMigrateTasks.dump
       end
     end
 
@@ -56,8 +56,7 @@ describe DataMigrate::Tasks::DataMigrateTasks do
 
       it 'overrides the default connection' do
         expect(ActiveRecord::Base).to receive(:establish_connection).with(override_config)
-
-        DataMigrate::Tasks::DataMigrateTasks.dump(connection_db_config)
+        DataMigrate::Tasks::DataMigrateTasks.dump
       end
     end
   end

--- a/spec/data_migrate/tasks/data_migrate_tasks_spec.rb
+++ b/spec/data_migrate/tasks/data_migrate_tasks_spec.rb
@@ -115,13 +115,13 @@ describe DataMigrate::Tasks::DataMigrateTasks do
 
     it "should display data migration status" do
       expect {
-        DataMigrate::Tasks::DataMigrateTasks.status(connection_db_config)
+        DataMigrate::Tasks::DataMigrateTasks.status
       }.to output(/up     20091231235959  Some name/).to_stdout
     end
 
     it "should display schema and data migration status" do
       expect {
-        DataMigrate::Tasks::DataMigrateTasks.status_with_schema(connection_db_config)
+        DataMigrate::Tasks::DataMigrateTasks.status_with_schema
       }.to output(match(/up      data   20091231235959  Some name/)
         .and match(/down    schema  20131111111111  Late migration/)).to_stdout
     end

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -6,7 +6,7 @@ namespace :db do
   namespace :migrate do
     desc "Migrate the database data and schema (options: VERSION=x, VERBOSE=false)."
     task :with_data => :environment do
-      DataMigrate::DataMigrator.assure_data_schema_table
+      DataMigrate::DataMigrator.create_data_schema_table
 
       ActiveRecord::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
       target_version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
@@ -59,7 +59,6 @@ namespace :db do
       desc 'Rollbacks the database one migration and re migrate up (options: STEP=x, VERSION=x).'
       task :with_data => :environment do
         DataMigrate::DataMigrator.create_data_schema_table
-
         if ENV["VERSION"]
           Rake::Task["db:migrate:down:with_data"].invoke
           Rake::Task["db:migrate:up:with_data"].invoke
@@ -75,7 +74,7 @@ namespace :db do
       task :with_data => :environment do
         version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
         raise "VERSION is required" unless version
-        DataMigrate::DataMigrator.assure_data_schema_table
+        DataMigrate::DataMigrator.create_data_schema_table
         run_both = ENV["BOTH"] == "true"
         migrations = DataMigrate::DatabaseTasks.pending_migrations.keep_if{|m| m[:version] == version}
 
@@ -97,7 +96,7 @@ namespace :db do
       task :with_data => :environment do
         version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
         raise "VERSION is required" unless version
-        DataMigrate::DataMigrator.assure_data_schema_table
+        DataMigrate::DataMigrator.create_data_schema_table
         run_both = ENV["BOTH"] == "true"
         migrations = DataMigrate::DatabaseTasks.past_migrations.keep_if{|m| m[:version] == version}
 
@@ -126,7 +125,7 @@ namespace :db do
     desc 'Rolls the schema back to the previous version (specify steps w/ STEP=n).'
     task :with_data => :environment do
       step = ENV['STEP'] ? ENV['STEP'].to_i : 1
-      DataMigrate::DataMigrator.assure_data_schema_table
+      DataMigrate::DataMigrator.create_data_schema_table
       DataMigrate::DatabaseTasks.past_migrations[0..(step - 1)].each do | past_migration |
         DataMigrate::DatabaseTasks.run_migration(past_migration, :down)
       end
@@ -139,7 +138,7 @@ namespace :db do
   namespace :forward do
     desc 'Pushes the schema to the next version (specify steps w/ STEP=n).'
     task :with_data => :environment do
-      DataMigrate::DataMigrator.assure_data_schema_table
+      DataMigrate::DataMigrator.create_data_schema_table
       step = ENV['STEP'] ? ENV['STEP'].to_i : 1
       DataMigrate::DatabaseTasks.forward(step)
       Rake::Task["db:_dump"].invoke
@@ -150,7 +149,7 @@ namespace :db do
   namespace :version do
     desc "Retrieves the current schema version numbers for data and schema migrations"
     task :with_data => :environment do
-      DataMigrate::DataMigrator.assure_data_schema_table
+      DataMigrate::DataMigrator.create_data_schema_table
       puts "Current Schema version: #{ActiveRecord::Migrator.current_version}"
       puts "Current Data version: #{DataMigrate::DataMigrator.current_version}"
     end
@@ -203,7 +202,7 @@ namespace :data do
   namespace :migrate do
     desc  'Rollbacks the database one migration and re migrate up (options: STEP=x, VERSION=x).'
     task :redo => :environment do
-      DataMigrate::DataMigrator.assure_data_schema_table
+      DataMigrate::DataMigrator.create_data_schema_table
       if ENV["VERSION"]
         Rake::Task["data:migrate:down"].invoke
         Rake::Task["data:migrate:up"].invoke
@@ -215,7 +214,7 @@ namespace :data do
 
     desc 'Runs the "up" for a given migration VERSION.'
     task :up => :environment do
-      DataMigrate::DataMigrator.assure_data_schema_table
+      DataMigrate::DataMigrator.create_data_schema_table
       version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
       raise "VERSION is required" unless version
       DataMigrate::DataMigrator.run(:up, DataMigrate::DatabaseTasks.data_migrations_path, version)
@@ -226,7 +225,7 @@ namespace :data do
     task :down => :environment do
       version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
       raise "VERSION is required" unless version
-      DataMigrate::DataMigrator.assure_data_schema_table
+      DataMigrate::DataMigrator.create_data_schema_table
       DataMigrate::DataMigrator.run(:down, DataMigrate::DatabaseTasks.data_migrations_path, version)
       Rake::Task["data:dump"].invoke
     end
@@ -239,7 +238,7 @@ namespace :data do
 
   desc 'Rolls the schema back to the previous version (specify steps w/ STEP=n).'
   task :rollback => :environment do
-    DataMigrate::DataMigrator.assure_data_schema_table
+    DataMigrate::DataMigrator.create_data_schema_table
     step = ENV['STEP'] ? ENV['STEP'].to_i : 1
     DataMigrate::DataMigrator.rollback(DataMigrate::DatabaseTasks.data_migrations_path, step)
     Rake::Task["data:dump"].invoke
@@ -247,7 +246,7 @@ namespace :data do
 
   desc 'Pushes the schema to the next version (specify steps w/ STEP=n).'
   task :forward => :environment do
-    DataMigrate::DataMigrator.assure_data_schema_table
+    DataMigrate::DataMigrator.create_data_schema_table
     step = ENV['STEP'] ? ENV['STEP'].to_i : 1
     # TODO: No worky for .forward
     # DataMigrate::DataMigrator.forward('db/data/', step)
@@ -260,7 +259,7 @@ namespace :data do
 
   desc "Retrieves the current schema version number for data migrations"
   task :version => :environment do
-    DataMigrate::DataMigrator.assure_data_schema_table
+    DataMigrate::DataMigrator.create_data_schema_table
     puts "Current data version: #{DataMigrate::DataMigrator.current_version}"
   end
 


### PR DESCRIPTION
Related to: https://github.com/ilyakatz/data-migrate/issues/268

This change removes the iteration over multiple databases. This will restore functionality to v9. 

Tested it on gusto codebase and it works ok. 