### PR TITLE
Write correct sha1 to internal metadata table

### DIFF
--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -66,6 +66,18 @@ module DataMigrate
           )
         end
       end
+
+      def schema_dump_path(db_config, format = ActiveRecord.schema_format)
+        return ENV["DATA_SCHEMA"] if ENV["DATA_SCHEMA"]
+        super.gsub(/(_)?schema\.rb\z/, '\1data_schema.rb')
+      end
+
+      # Override this method from `ActiveRecord::Tasks::DatabaseTasks`
+      # to ensure that the sha saved in ar_internal_metadata table
+      # is from the original schema.rb file
+      def schema_sha1(file)
+        super(file.gsub(/data_schema.rb\z/, 'schema.rb'))
+      end
     end
 
     def self.forward(step = 1)


### PR DESCRIPTION
# Changes

Related to: https://github.com/ilyakatz/data-migrate/issues/268
 
The incorrect sha1 is saved to the ar_internal_metadata table because it uses the sha1 for `data_schema.rb` file instead of the original `schema.rb` file. This happens because data migrate uses Active Record's `schema:load` to load data migrations. This fix ensures that the correct sha is used. 