### PR TITLE
Remove the need for empty data_schema files for non-primary databases

### DIFF
--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -69,6 +69,10 @@ module DataMigrate
 
       def schema_dump_path(db_config, format = ActiveRecord.schema_format)
         return ENV["DATA_SCHEMA"] if ENV["DATA_SCHEMA"]
+
+        # We only require a schema.rb file for the primary database
+        return unless db_config.primary?
+
         super.gsub(/(_)?schema\.rb\z/, '\1data_schema.rb')
       end
 


### PR DESCRIPTION
## Changes 

Related to: https://github.com/ilyakatz/data-migrate/issues/268

If you have multiple databases, you will see this error requiring you to create an empty data_schema.rb file in order to run data migrations. 
  ```
  /Users/maple/test-rails-app/db/bleep_data_schema.rb doesn't exist yet. Run `rake data:migrate` to create it, then try again.
  ```
  The data schema file for non-primary databases does not have a functionality at the present time. This change removes the need for it. 

You may now delete those files from your application folder. 
