### PR TITLE
Add task db:prepare:with_data

### DIFF
--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -225,6 +225,8 @@ module DataMigrate
       seed = false
 
       each_current_configuration(env) do |db_config|
+        next unless db_config.primary?
+        
         with_temporary_pool(db_config) do
           begin
             database_initialized = migration_connection.schema_migration.table_exists?

--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -44,6 +44,22 @@ module DataMigrate
       ensure
         migration_class.connection_handler.establish_connection(original_db_config)
       end
+
+      def with_temporary_pool(db_config)
+        original_db_config = migration_class.connection_db_config
+        pool = migration_class.establish_connection(db_config)
+        yield pool
+      ensure
+        migration_class.establish_connection(original_db_config)
+      end
+
+      def migration_class # :nodoc:
+        ActiveRecord::Base
+      end
+
+      def migration_connection # :nodoc:
+        migration_class.connection
+      end
     end
 
     def db_configs_with_versions

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -146,6 +146,13 @@ namespace :db do
       end
     end
   end
+
+  namespace :prepare do
+    desc "Runs setup if database does not exist, or runs data and schema migrations if it does"
+    task with_data: :environment do
+      DataMigrate::DatabaseTasks.prepare_all_with_data
+    end
+  end
 end
 
 namespace :data do

--- a/tasks/databases.rake
+++ b/tasks/databases.rake
@@ -6,34 +6,7 @@ namespace :db do
   namespace :migrate do
     desc "Migrate the database data and schema (options: VERSION=x, VERBOSE=false)."
     task :with_data => :load_config do
-      DataMigrate::DataMigrator.create_data_schema_table
-      ActiveRecord::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
-
-      db_configs = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env)
-
-      schema_mapped_versions = ActiveRecord::Tasks::DatabaseTasks.db_configs_with_versions(db_configs)
-      data_mapped_versions = DataMigrate::DatabaseTasks.db_configs_with_versions
-
-      mapped_versions = schema_mapped_versions.merge(data_mapped_versions) do |_key, schema_db_configs, data_db_configs|
-        schema_db_configs + data_db_configs
-      end
-
-      mapped_versions.sort.each do |version, db_configs|
-        db_configs.each do |db_config|
-          if is_data_migration = db_config.is_a?(DataMigrate::DatabaseConfigurationWrapper)
-            db_config = db_config.db_config
-          end
-
-          DataMigrate::DatabaseTasks.with_temporary_connection(db_config) do
-            if is_data_migration
-              DataMigrate::DataMigrator.run(:up, DataMigrate::DatabaseTasks.data_migrations_path, version)
-            else
-              ActiveRecord::Tasks::DatabaseTasks.migrate(version)
-            end
-          end
-        end
-      end
-
+      DataMigrate::DatabaseTasks.migrate_with_data
       Rake::Task["db:_dump"].invoke
       Rake::Task["data:dump"].invoke
     end


### PR DESCRIPTION
This is my attempt at #215. At the moment there's lots of code copied out of rails, it needs DRYing up a bit, and it needs tests adding. I'll work on it some more before making this ready for review, but it seems to work...

This is basically a direct copy of ActiveRecord::Tasks::DatabaseTasks#prepare_all, but instead of calling migrate, it calls migrate_with_data (refactored out of databases.rake), and adds data-appropriate calles into schema loading and dumping code as well. 

Original code is at https://github.com/rails/rails/blob/5ed37b35d666b833aeccb14a4cacd2926251232d/activerecord/lib/active_record/tasks/database_tasks.rb#L176

The code is on a feature branch off the 9.1.0 tag at the moment, as I know there's a lot of work going on with v10, and I didn't want to start stepping on toes there; also, that's the version I'm using in production so that's where I needed it :)