### PR TITLE
Inherit from ActiveRecord::SchemaMigration directly

### DIFF
--- a/lib/data_migrate/data_schema_migration.rb
+++ b/lib/data_migrate/data_schema_migration.rb
@@ -1,13 +1,12 @@
 module DataMigrate
-  class DataSchemaMigration
+  class DataSchemaMigration < ActiveRecord::SchemaMigration
     class << self
-      delegate :table_name, :primary_key, :create_table, :normalized_versions, :create, :create!, :table_exists?, :exists?, :where, to: :instance
+      def table_name
+        ActiveRecord::Base.table_name_prefix + 'data_migrations' + ActiveRecord::Base.table_name_suffix
+      end
 
-      def instance
-        @instance ||= Class.new(::ActiveRecord::SchemaMigration) do
-          define_singleton_method(:table_name) { ActiveRecord::Base.table_name_prefix + 'data_migrations' + ActiveRecord::Base.table_name_suffix }
-          define_singleton_method(:primary_key) { "version" }
-        end
+      def primary_key
+        "version"
       end
     end
   end


### PR DESCRIPTION
Instead of delegating methods and creating an instance, we can just inherit from `ActiveRecord::SchemaMigration`. 