### PR TITLE
Fix status_with_schema with multiple migrations path (Engine)

### DIFF
--- a/lib/data_migrate/tasks/data_migrate_tasks.rb
+++ b/lib/data_migrate/tasks/data_migrate_tasks.rb
@@ -55,7 +55,9 @@ module DataMigrate
         db_list_schema = DataMigrate::RailsHelper.schema_migration_versions
         file_list = []
 
-        Dir.foreach(File.join(Rails.root, migrations_paths)) do |file|
+        Array(migrations_paths).map do |path|
+          Dir.children(path) if Dir.exist?(path)
+        end.flatten.compact.each do |file|
           # only files matching "20091231235959_some_name.rb" pattern
           if match_data = /(\d{14})_(.+)\.rb/.match(file)
             status = db_list_data.delete(match_data[1]) ? 'up' : 'down'

--- a/spec/db_two/data/20111231235959_some_other_name.rb
+++ b/spec/db_two/data/20111231235959_some_other_name.rb
@@ -1,0 +1,9 @@
+class SomeOtherName < ActiveRecord::Migration[6.1]
+  def up
+    puts "Doing data migration"
+  end
+
+  def down
+    puts "Undoing SomeName"
+  end
+end


### PR DESCRIPTION
The `Dir.foreach(File.join(Rails.root, migrations_paths))` just doesn't handle multiple data migrations paths. So I took a shot at fixing it.