### PR TITLE
Reset model schema cache before each run

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.4.0
+- Reset model schema cache before each data migration https://github.com/ilyakatz/data-migrate/pull/307
+
 ## 9.3.0
 - Improve with_data Rake task for multiple database https://github.com/ilyakatz/data-migrate/pull/296
 

--- a/lib/data_migrate/data_migrator.rb
+++ b/lib/data_migrate/data_migrator.rb
@@ -54,6 +54,10 @@ module DataMigrate
 
       #TODO: this was added to be backward compatible, need to re-evaluate
       def run(direction, migration_paths, version)
+        # Ensure all Active Record model cache is reset for each data migration
+        # As recommended in: https://github.com/rails/rails/blob/da21c2e9812e5eb0698fba4a9aa38632fc004432/activerecord/lib/active_record/migration.rb#L467-L470
+        ActiveRecord::Base.descendants.each(&:reset_column_information)
+
         DataMigrate::MigrationContext.new(migration_paths).run(direction, version)
       end
 


### PR DESCRIPTION
We want to reset the model schema cache to ensure we're using the latest model schema for each data migration run.  

Fixes: https://github.com/ilyakatz/data-migrate/issues/306 and https://github.com/ilyakatz/data-migrate/pull/251