### PR TITLE
fix for `rails g data_migration` with multiple data migration paths 

### DIFF
--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -39,7 +39,7 @@ module DataMigrate
       end
 
       def data_migrations_path
-        DataMigrate.config.data_migrations_path
+        Array(DataMigrate.config.data_migrations_path).first
       end
     end
   end

--- a/spec/generators/data_migration/data_migration_generator_spec.rb
+++ b/spec/generators/data_migration/data_migration_generator_spec.rb
@@ -61,6 +61,20 @@ describe DataMigrate::Generators::DataMigrationGenerator do
         subject.create_data_migration
       end
     end
+
+    context 'when custom data migrations path contains an array of paths' do
+      before do
+        DataMigrate.config.data_migrations_path = ['abc', 'def']
+      end
+
+      it 'returns the first file path' do
+        is_expected.to receive(:migration_template).with(
+          'data_migration.rb', data_migrations_file_path
+        )
+
+        subject.create_data_migration
+      end
+    end
   end
 
   describe ".source_root" do


### PR DESCRIPTION
The proposed solution for Rails engines with multiple data migration paths causes a side-effect.

https://github.com/ilyakatz/data-migrate/issues/314

```
module EngineName
  class Engine < ::Rails::Engine
    initializer :engine_name do |app|
      ::DataMigrate.configure do |data_migrate|
        default_path = ::DataMigrate::Config.new.data_migrations_path
        data_migrate.data_migrations_path = [default_path, root.join('db', 'data')]
      end
    end
  end
end
```

The resulting migration file path is made up of all of the paths names so in our case it was `./db/data/engines/db/data/engines/something/db/data`. This fix just picks the first path ie. the application's db/data path.

Hope this is helpful.