### PR TITLE
Change db_configs_with_versions call when Rails is higher than 7.1

### DIFF
--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -179,9 +179,14 @@ module DataMigrate
 
       ActiveRecord::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
 
-      db_configs = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env)
+      schema_mapped_versions = if rails_version_equal_to_or_higher_than_7_1
+        ActiveRecord::Tasks::DatabaseTasks.db_configs_with_versions
+      else
+        db_configs = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env)
 
-      schema_mapped_versions = ActiveRecord::Tasks::DatabaseTasks.db_configs_with_versions(db_configs)
+        ActiveRecord::Tasks::DatabaseTasks.db_configs_with_versions(db_configs)
+      end
+
       data_mapped_versions = DataMigrate::DatabaseTasks.db_configs_with_versions
 
       mapped_versions = schema_mapped_versions.merge(data_mapped_versions) do |_key, schema_db_configs, data_db_configs|

--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -179,7 +179,7 @@ module DataMigrate
 
       ActiveRecord::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
 
-      schema_mapped_versions = if rails_version_equal_to_or_higher_than_7_1
+      schema_mapped_versions = if DataMigrate::RailsHelper.rails_version_equal_to_or_higher_than_7_1
         ActiveRecord::Tasks::DatabaseTasks.db_configs_with_versions
       else
         db_configs = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env)


### PR DESCRIPTION
[Before Rails 7.1](https://github.com/rails/rails/blob/7-0-stable/activerecord/lib/active_record/tasks/database_tasks.rb#L277)

`def db_configs_with_versions(db_configs)`

>= Rails 7.1

`def db_configs_with_versions(environment = env)`

This is producing and error because is overriding the env and not finding pending migrations

### Error screenshot

![image](https://github.com/user-attachments/assets/862b4099-161a-45c8-be23-2c10b756d9ff)
