### PR TITLE
Github action update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-20.04" ]
+        os: [ "ubuntu-24.04" ]
         ruby:
           - '3.1'
           - '3.2'
@@ -25,7 +25,7 @@ jobs:
       RAILS_ENV: test
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Update Ubuntu version for Ruby Setup
Update checkout action version to avoid warnings

That's just tidying things up a bit and avoiding potential future issues