### PR TITLE
feat: Allow multiple data_migrations_path values

### DIFF
--- a/lib/data_migrate/data_migrator.rb
+++ b/lib/data_migrate/data_migrator.rb
@@ -12,7 +12,7 @@ module DataMigrate
 
     class << self
       def migrations_paths
-        [DataMigrate.config.data_migrations_path]
+        Array.wrap(DataMigrate.config.data_migrations_path)
       end
 
       def create_data_schema_table

--- a/lib/data_migrate/data_schema.rb
+++ b/lib/data_migrate/data_schema.rb
@@ -29,13 +29,13 @@ module DataMigrate
     end
 
     def versions
-      @versions ||= begin
-        versions = []
-        Dir.foreach(DataMigrate::DataMigrator.full_migrations_path) do |file|
-          match_data = DataMigrate::DataMigrator.match(file)
-          versions << match_data[1].to_i if match_data
+      @versions ||= Set.new.tap do |versions|
+        DataMigrate::DataMigrator.migrations_paths.each do |path|
+          Dir.foreach(path) do |file|
+            match_data = DataMigrate::DataMigrator.match(file)
+            versions << match_data[1].to_i if match_data
+          end
         end
-        versions
       end
     end
 

--- a/lib/data_migrate/tasks/data_migrate_tasks.rb
+++ b/lib/data_migrate/tasks/data_migrate_tasks.rb
@@ -6,7 +6,7 @@ module DataMigrate
       extend self
 
       def migrations_paths
-        @migrations_paths ||= DataMigrate.config.data_migrations_path
+        @migrations_paths ||= Array.wrap(DataMigrate.config.data_migrations_path)
       end
 
       def dump
@@ -55,11 +55,13 @@ module DataMigrate
         db_list_schema = DataMigrate::RailsHelper.schema_migration_versions
         file_list = []
 
-        Dir.foreach(File.join(Rails.root, migrations_paths)) do |file|
-          # only files matching "20091231235959_some_name.rb" pattern
-          if match_data = /(\d{14})_(.+)\.rb/.match(file)
-            status = db_list_data.delete(match_data[1]) ? 'up' : 'down'
-            file_list << [status, match_data[1], match_data[2], 'data']
+        migrations_paths.each do |path|
+          Dir.foreach(File.join(Rails.root, path)) do |file|
+            # only files matching "20091231235959_some_name.rb" pattern
+            if match_data = /(\d{14})_(.+)\.rb/.match(file)
+              status = db_list_data.delete(match_data[1]) ? 'up' : 'down'
+              file_list << [status, match_data[1], match_data[2], 'data']
+            end
           end
         end
 

--- a/lib/generators/data_migration/data_migration_generator.rb
+++ b/lib/generators/data_migration/data_migration_generator.rb
@@ -38,8 +38,9 @@ module DataMigrate
         File.join(data_migrations_path, "#{file_name}.rb")
       end
 
+      # Use the first path in the data_migrations_path as the target directory
       def data_migrations_path
-        DataMigrate.config.data_migrations_path
+        Array.wrap(DataMigrate.config.data_migrations_path).first
       end
     end
   end

--- a/spec/data_migrate/data_migrator_spec.rb
+++ b/spec/data_migrate/data_migrator_spec.rb
@@ -51,9 +51,10 @@ describe DataMigrate::DataMigrator do
   describe "#migrations_status" do
     it "returns all migrations statuses" do
       status = described_class.migrations_status
-      expect(status.length).to eq 2
+      expect(status.length).to eq 3
       expect(status.first).to eq ["down", "20091231235959", "Some name"]
       expect(status.second).to eq ["down", "20171231235959", "Super update"]
+      expect(status.third).to eq ["down", "20241231235959", "Data two update"]
     end
   end
 

--- a/spec/db/data_two/20241231235959_data_two_update.rb
+++ b/spec/db/data_two/20241231235959_data_two_update.rb
@@ -1,0 +1,9 @@
+class DataTwoUpdate < ActiveRecord::Migration[6.1]
+  def up
+    puts "Doing DataTwoUpdate"
+  end
+
+  def down
+    puts "Undoing DataTwoUpdate"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ RSpec.configure do |config|
     else
       @prev_data_migrations_path = DataMigrate.config.data_migrations_path
       DataMigrate.configure do |config|
-        config.data_migrations_path = "spec/db/data"
+        config.data_migrations_path = ["spec/db/data", "spec/db/data_two"]
       end
     end
   end


### PR DESCRIPTION
This PR adds the ability for multiple `data_migration_paths` to be set. This is useful for Rails applications leveraging
tools like Packwerk / Packs to split up their codebase into multiple packages.

Multiple paths can be specified in the `data_migration_paths` configuration option, however the default of one path is
still valid.

```ruby
# config/initializers/data_migrate.rb

DataMigrate.configure do |config|
  config.data_migrations_path = ['db/data/'] + Dir['packs/**/db/data']
end
```

The first path in the array is the default path which is used when generating new data migration files.

Much of this code was borrowed from #244, but I had to make some changes to get it working with the latest version.
