### PR TITLE
fix(database_tasks): ConnectionPool deprecation warning in Rails 7.2

### DIFF
--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -22,9 +22,9 @@ module DataMigrate
         end
       end
 
-      def with_temporary_connection(db_config) # :nodoc:
-        with_temporary_pool(db_config) do |pool|
-          yield pool.connection
+      def with_temporary_connection(db_config, clobber: false, &block) # :nodoc:
+        with_temporary_pool(db_config, clobber: clobber) do |pool|
+          pool.with_connection(&block)
         end
       end
 
@@ -36,13 +36,13 @@ module DataMigrate
         migration_class.connection
       end
 
-      private def with_temporary_pool(db_config)
+      private def with_temporary_pool(db_config, clobber: false)
         original_db_config = migration_class.connection_db_config
-        pool = migration_class.connection_handler.establish_connection(db_config)
+        pool = migration_class.connection_handler.establish_connection(db_config, clobber: clobber)
 
         yield pool
       ensure
-        migration_class.connection_handler.establish_connection(original_db_config)
+        migration_class.connection_handler.establish_connection(original_db_config, clobber: clobber)
       end
     end
 


### PR DESCRIPTION
Fixes this deprecation warning raised in Rails 7.2:

```
DEPRECATION WARNING: ActiveRecord::ConnectionAdapters::ConnectionPool#connection is deprecated
and will be removed in Rails 8.0. Use #lease_connection instead.
```

The changed code is simply copied from the Rails repository, please see https://github.com/rails/rails/blob/97169912f197eee6e76fafb091113bddf624aa67/activerecord/lib/active_record/tasks/database_tasks.rb#L520 and
https://github.com/rails/rails/blob/97169912f197eee6e76fafb091113bddf624aa67/activerecord/lib/active_record/tasks/database_tasks.rb#L550.

see #340 