### PR TITLE
fix: db:schema:load for rails 6.0.x versions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 9.1.2
+
+- Fix #281 to maintain rails 6.0 support. (#342)
+
+## 9.1.1
+
+- Backport Fix data:schema:load for structure.sql (#281)
+
 ## 9.1.0
 
 - Fix a bug that caused `schema_sha1` in `ar_internal_metadata` to be reset to the `data_schema.rb` file. (#272)

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -3,6 +3,6 @@
 source "http://rubygems.org"
 
 gem "sqlite3", "~> 1.4"
-gem "rails", "~> 7.0"
+gem "rails", "~> 7.0.0"
 
 gemspec path: "../"

--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -74,14 +74,22 @@ module DataMigrate
         # We only require a schema.rb file for the primary database
         return unless db_config.primary?
 
-        File.join(File.dirname(ActiveRecord::Tasks::DatabaseTasks.schema_dump_path(db_config, format)), schema_file_type)
+        if Gem::Dependency.new("railties", ">= 6.1").match?("railties", Gem.loaded_specs["railties"].version)
+          File.join(File.dirname(ActiveRecord::Tasks::DatabaseTasks.schema_dump_path(db_config, format)), schema_file_type)
+        else
+          super.gsub(/(_)?schema\.rb\z/, '\1data_schema.rb')
+        end
       end
 
       # Override this method from `ActiveRecord::Tasks::DatabaseTasks`
       # to ensure that the sha saved in ar_internal_metadata table
       # is from the original schema.rb file
       def schema_sha1(file)
-        ActiveRecord::Tasks::DatabaseTasks.schema_dump_path(ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: "primary"))
+        if Gem::Dependency.new("railties", ">= 6.1").match?("railties", Gem.loaded_specs["railties"].version)
+          ActiveRecord::Tasks::DatabaseTasks.schema_dump_path(ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: "primary"))
+        else
+          super(file.gsub(/data_schema.rb\z/, 'schema.rb'))
+        end
       end
     end
 

--- a/lib/data_migrate/version.rb
+++ b/lib/data_migrate/version.rb
@@ -1,3 +1,3 @@
 module DataMigrate
-  VERSION = "9.1.1".freeze
+  VERSION = "9.1.2".freeze
 end


### PR DESCRIPTION
This PR is only relevant for the 9.1.x branch/tags and aims to fix #338 