### PR TITLE
fix: allow db:schema:load to work for rails 6.0 and 6.1

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -7,5 +7,5 @@ appraise 'rails-6.1' do
 end
 
 appraise 'rails-7.0' do
-  gem 'rails', '~> 7.0'
+  gem 'rails', '~> 7.0.0'
 end

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## 9.1.3
+
+- Fix #342 for schema load on rails 6.x. (#343)
+
 ## 9.1.2
 
 - Fix #281 to maintain rails 6.0 support. (#342)

--- a/lib/data_migrate/version.rb
+++ b/lib/data_migrate/version.rb
@@ -1,3 +1,3 @@
 module DataMigrate
-  VERSION = "9.1.2".freeze
+  VERSION = "9.1.3".freeze
 end


### PR DESCRIPTION
Still planning to only release this for 9-1. I suspect a better fix for 6.1 that would also support multi-databases might be a bit more tricky.
For a bit of context:
schema_dump_path is introduced in rails 7 and our task relies on that to improve the support for multiple databases, however full multiple data support was only handled in subsequent gem versions, so I'm hoping this patch will solve rails 6.x issues for people still using older rails versions.