### PR TITLE
Update README instruction for engines path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,11 @@ From now on capistrano will run `rake db:migrate:with_data` in every deploy.
 
 This gem also has a initial support for adding data migrations inside Rails engines.
 Just add your engines directory pattern to data_migrations initializer, for example 
-in the case your engines are located in `components` folder you can set it up like this:
+in the case your engines are located in `engines` folder you can set it up like this:
 
 ```ruby
 DataMigrate.configure do |config|
-  config.data_migrations_path = ['db/data'] + Dir['components/**/db/data']
+  config.data_migrations_path = ['db/data'] + Dir['engines/**/db/data']
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -144,19 +144,12 @@ From now on capistrano will run `rake db:migrate:with_data` in every deploy.
 ## Rails Engines support
 
 This gem also has a initial support for adding data migrations inside Rails engines.
-Inside the Engine's class initializer (the one that inherits from `Rails::Engine`, usually inside `engines/ENGINE_NAME/lib/engine.rb`) you need to add something like this:
-
+Just add your engines directory pattern to data_migrations initializer, for example 
+in the case your engines are located in `components` folder you can set it up like this:
 
 ```ruby
-module EngineName
-  class Engine < ::Rails::Engine
-    initializer :engine_name do |app|
-      ::DataMigrate.configure do |data_migrate|
-        default_path = ::DataMigrate::Config.new.data_migrations_path
-        data_migrate.data_migrations_path = [default_path, root.join('db', 'data')]
-      end
-    end
-  end
+DataMigrate.configure do |config|
+  config.data_migrations_path = ['db/data'] + Dir['components/**/db/data']
 end
 ```
 


### PR DESCRIPTION
Since last version, support for Rails multi-engine setup has been included. However the README don't include instructions on how to configure it.

Additionally, we have never been able to make this feature work with the old "Rails Engines support" section instructions.

In this PR I propose to change this section for instructions on how to actually use the multiple `data_migrations_path` approach to get the same results with additional simplicity (you don't need to modify your engines initializers)