### PR TITLE
Add SimpleCov to collect code coverage info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ spec/db/data_schema.rb
 .idea/
 vendor/
 Gemfile.lock
+coverage/

--- a/data_migrate.gemspec
+++ b/data_migrate.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "timecop"
   s.add_development_dependency "rubocop"
   s.add_development_dependency "overcommit"
+  s.add_development_dependency "simplecov"
 end

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -79,6 +79,7 @@ GEM
     crass (1.0.6)
     date (3.3.4)
     diff-lcs (1.5.0)
+    docile (1.4.1)
     erubi (1.13.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -190,6 +191,12 @@ GEM
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -217,6 +224,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -230,6 +238,7 @@ DEPENDENCIES
   rspec
   rspec-core
   rubocop
+  simplecov
   sqlite3
   timecop
 

--- a/gemfiles/rails_7.0.gemfile.lock
+++ b/gemfiles/rails_7.0.gemfile.lock
@@ -85,6 +85,7 @@ GEM
     crass (1.0.6)
     date (3.3.4)
     diff-lcs (1.5.0)
+    docile (1.4.1)
     erubi (1.13.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -198,6 +199,12 @@ GEM
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sqlite3 (1.7.2-aarch64-linux)
     sqlite3 (1.7.2-arm64-darwin)
     sqlite3 (1.7.2-x86_64-darwin)
@@ -218,6 +225,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -231,6 +239,7 @@ DEPENDENCIES
   rspec
   rspec-core
   rubocop
+  simplecov
   sqlite3
   timecop
 

--- a/gemfiles/rails_7.1.gemfile.lock
+++ b/gemfiles/rails_7.1.gemfile.lock
@@ -97,6 +97,7 @@ GEM
     crass (1.0.6)
     date (3.3.4)
     diff-lcs (1.5.0)
+    docile (1.4.1)
     drb (2.2.1)
     erubi (1.13.0)
     globalid (1.2.1)
@@ -232,6 +233,12 @@ GEM
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sqlite3 (1.7.2)
       mini_portile2 (~> 2.8.0)
     sqlite3 (1.7.2-aarch64-linux)
@@ -270,6 +277,7 @@ DEPENDENCIES
   rspec
   rspec-core
   rubocop
+  simplecov
   sqlite3
   timecop
 

--- a/gemfiles/rails_7.2.gemfile.lock
+++ b/gemfiles/rails_7.2.gemfile.lock
@@ -93,6 +93,7 @@ GEM
     crass (1.0.6)
     date (3.3.4)
     diff-lcs (1.5.1)
+    docile (1.4.1)
     drb (2.2.1)
     erubi (1.13.0)
     globalid (1.2.1)
@@ -230,6 +231,12 @@ GEM
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
     securerandom (0.3.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sqlite3 (2.0.2-aarch64-linux-gnu)
     sqlite3 (2.0.2-arm64-darwin)
     sqlite3 (2.0.2-x86_64-darwin)
@@ -267,6 +274,7 @@ DEPENDENCIES
   rspec
   rspec-core
   rubocop
+  simplecov
   sqlite3
   timecop
 

--- a/gemfiles/rails_8.0.gemfile.lock
+++ b/gemfiles/rails_8.0.gemfile.lock
@@ -96,6 +96,7 @@ GEM
     crass (1.0.6)
     date (3.4.0)
     diff-lcs (1.5.1)
+    docile (1.4.1)
     drb (2.2.1)
     erubi (1.13.0)
     globalid (1.2.1)
@@ -231,6 +232,12 @@ GEM
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
     securerandom (0.3.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sqlite3 (2.1.0)
       mini_portile2 (~> 2.8.0)
     sqlite3 (2.1.0-aarch64-linux-gnu)
@@ -270,6 +277,7 @@ DEPENDENCIES
   rspec
   rspec-core
   rubocop
+  simplecov
   sqlite3
   timecop
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 require 'rspec'
 require 'rails'
 require 'sqlite3'


### PR DESCRIPTION
This is not to be merge just yet, as this is some boilerplate to see the current status of the gem and which parts of it are tested and which parts are not.

So far it doesn't really merge anything from `appraisal` and running different Rails versions, so I might close it soon enough without merging

Even so, it does give insight into what we've been doing and testing so far. Hopefully it'll help us identify Rails 8 and Rails 6.1 issues quicker