### PR TITLE
Add configuration for table name

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ You can override this setting in `config/initializers/data_migrate.rb`
 
 ```ruby
 DataMigrate.configure do |config|
+  config.data_migrations_table_name = 'my_migrations_database_name'
   config.data_migrations_path = 'db/awesomepath/'
   config.data_template_path = Rails.root.join("lib", "awesomepath", "custom_data_migration.rb")
   config.db_configuration = {

--- a/lib/data_migrate/config.rb
+++ b/lib/data_migrate/config.rb
@@ -12,11 +12,12 @@ module DataMigrate
   end
 
   class Config
-    attr_accessor :data_migrations_path, :data_template_path, :db_configuration, :spec_name
+    attr_accessor :data_migrations_table_name, :data_migrations_path, :data_template_path, :db_configuration, :spec_name
 
     DEFAULT_DATA_TEMPLATE_PATH = "data_migration.rb"
 
     def initialize
+      @data_migrations_table_name = "data_migrations"
       @data_migrations_path = "db/data/"
       @data_template_path = DEFAULT_DATA_TEMPLATE_PATH
       @db_configuration = nil

--- a/lib/data_migrate/data_schema_migration.rb
+++ b/lib/data_migrate/data_schema_migration.rb
@@ -4,7 +4,7 @@ module DataMigrate
     # So we only load the appropriate methods depending on Rails version.
     if DataMigrate::RailsHelper.rails_version_equal_to_or_higher_than_7_1
       def table_name
-        ActiveRecord::Base.table_name_prefix + 'data_migrations' + ActiveRecord::Base.table_name_suffix
+        ActiveRecord::Base.table_name_prefix + DataMigrate.config.data_migrations_table_name + ActiveRecord::Base.table_name_suffix
       end
 
       def primary_key
@@ -13,7 +13,7 @@ module DataMigrate
     else
       class << self
         def table_name
-          ActiveRecord::Base.table_name_prefix + 'data_migrations' + ActiveRecord::Base.table_name_suffix
+          ActiveRecord::Base.table_name_prefix + DataMigrate.config.data_migrations_table_name + ActiveRecord::Base.table_name_suffix
         end
 
         def primary_key

--- a/spec/data_migrate/data_schema_migration_spec.rb
+++ b/spec/data_migrate/data_schema_migration_spec.rb
@@ -9,6 +9,27 @@ describe DataMigrate::DataSchemaMigration do
       it "returns correct table name" do
         expect(subject.table_name).to eq("data_migrations")
       end
+
+      describe "when data migrations table name configured" do
+        let(:data_migrations_table_name) { "my_app_data_template_migrations"}
+
+        before do
+          @before = DataMigrate.config.data_migrations_table_name
+          DataMigrate.configure do |config|
+            config.data_migrations_table_name = data_migrations_table_name
+          end
+        end
+
+        after do
+          DataMigrate.configure do |config|
+            config.data_migrations_table_name = @before
+          end
+        end
+
+        it "returns correct table name" do
+          expect(subject.table_name).to eq(data_migrations_table_name)
+        end
+      end
     end
 
     describe :index_name do
@@ -21,6 +42,27 @@ describe DataMigrate::DataSchemaMigration do
     describe :table_name do
       it "returns correct table name" do
         expect(subject.table_name).to eq("data_migrations")
+      end
+
+      describe "when data migrations table name configured" do
+        let(:data_migrations_table_name) { "my_app_data_template_migrations"}
+
+        before do
+          @before = DataMigrate.config.data_migrations_table_name
+          DataMigrate.configure do |config|
+            config.data_migrations_table_name = data_migrations_table_name
+          end
+        end
+
+        after do
+          DataMigrate.configure do |config|
+            config.data_migrations_table_name = @before
+          end
+        end
+
+        it "returns correct table name" do
+          expect(subject.table_name).to eq(data_migrations_table_name)
+        end
       end
     end
 


### PR DESCRIPTION
At Leafly, we needed to configure a different table name for the data migrations — which we've accomplished to this point by forking the gem and adding the configuration option added in this pull request.

I'd like to get back on the mainline gem releases to get the Rails 7.1+ compatibility updates and retire our fork, but needing to change the table name prevents me from doing so.

Hopefully this looks okay, but if there are changes I can make to get this added I'd happily do so.