### PR TITLE
Schema version -- do formatted version like activerecord

### DIFF
--- a/lib/data_migrate/schema_dumper.rb
+++ b/lib/data_migrate/schema_dumper.rb
@@ -39,7 +39,7 @@ module DataMigrate
     def formatted_version
       stringified = @version.to_s
       return stringified unless stringified.length == 14
-      stringified.insert(4, "_").insert(7, "_").insert(10, "_")      
+      stringified.insert(4, "_").insert(7, "_").insert(10, "_")
     end
   end
 end

--- a/lib/data_migrate/schema_dumper.rb
+++ b/lib/data_migrate/schema_dumper.rb
@@ -15,7 +15,7 @@ module DataMigrate
     end
 
     def dump(stream)
-      define_params = @version ? "version: #{@version}" : ""
+      define_params = @version ? "version: #{formatted_version}" : ""
 
       stream.puts "DataMigrate::Data.define(#{define_params})"
 
@@ -33,6 +33,13 @@ module DataMigrate
                   rescue StandardError
                     0
                   end
+    end
+
+    # turns 20170404131909 into "2017_04_04_131909"
+    def formatted_version
+      stringified = @version.to_s
+      return stringified unless stringified.length == 14
+      stringified.insert(4, "_").insert(7, "_").insert(10, "_")      
     end
   end
 end

--- a/spec/data_migrate/schema_dumper_spec.rb
+++ b/spec/data_migrate/schema_dumper_spec.rb
@@ -28,7 +28,7 @@ describe DataMigrate::SchemaDumper do
       DataMigrate::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
       stream.rewind
 
-      last_version = fixture_file_timestamps.last.insert(4, "_").insert(7, "_").insert(10, "_")
+      last_version = fixture_file_timestamps.last.dup.insert(4, "_").insert(7, "_").insert(10, "_")
       expected = "DataMigrate::Data.define(version: #{last_version})"
       expect(stream.read).to include expected
     end

--- a/spec/data_migrate/schema_dumper_spec.rb
+++ b/spec/data_migrate/schema_dumper_spec.rb
@@ -28,7 +28,7 @@ describe DataMigrate::SchemaDumper do
       DataMigrate::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
       stream.rewind
 
-      last_version = fixture_file_timestamps.last
+      last_version = fixture_file_timestamps.last.insert(4, "_").insert(7, "_").insert(10, "_")
       expected = "DataMigrate::Data.define(version: #{last_version})"
       expect(stream.read).to include expected
     end


### PR DESCRIPTION
Adds in a formatted version number to the schema record similar to how [it is done in activerecord](https://github.com/rails/rails/blob/17cde11cd13cf07a7d6c712cb1593881496abacb/activerecord/lib/active_record/schema_dumper.rb#L85-L90) which leads to easier to read conflict resolutions.

E.g. converting
```ruby
DataMigrate::Data.define(version: 20250415225942)

```

into

```ruby
DataMigrate::Data.define(version: 2025_04_15_225942)
```

just like an activerecord schema looks:
```ruby
ActiveRecord::Schema[7.2].define(version: 2025_04_16_223838) do
```