### PR TITLE
Patch `ActiveRecord::ConnectionNotEstablished` snag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ gemfiles/.bundle
 spec/db/test.db
 spec/db/other_test.db
 spec/db/data_schema.rb
+spec/db/secondary_test.db
+spec/db/*.db-shm
+spec/db/*.db-wal
 .vscode/
 .DS_Store
 .ruby-gemset

--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -286,9 +286,10 @@ module DataMigrate
     # Match Rails db:prepare behavior: a provisioned-but-empty database still
     # needs the schema restored before migrations run.
     def self.database_initialized?(pool)
-      return pool.with_connection { DataMigrate::RailsHelper.schema_migration.table_exists? } if pool.respond_to?(:with_connection)
+      schema_migration = DataMigrate::RailsHelper.schema_migration
+      return pool.with_connection { |connection| connection.data_source_exists?(schema_migration.table_name) } if pool.respond_to?(:with_connection)
 
-      DataMigrate::RailsHelper.schema_migration.table_exists?
+      schema_migration.table_exists?
     end
 
     def self.load_schema_for(db_config)

--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -267,10 +267,15 @@ module DataMigrate
       seeded_database = false
 
       with_temporary_pool(db_config) do |pool|
-        connection = pooled_connection(pool)
-        next if database_exists?(connection)
+        begin
+          database_initialized = database_initialized?(pool)
+        rescue ActiveRecord::NoDatabaseError
+          create(db_config)
+          retry
+        end
 
-        create(db_config)
+        next if database_initialized
+
         load_schema_for(db_config)
         seeded_database = seeds?(db_config)
       end
@@ -278,10 +283,12 @@ module DataMigrate
       seeded_database
     end
 
-    def self.pooled_connection(pool)
-      return pool.lease_connection if pool.respond_to?(:lease_connection)
+    # Match Rails db:prepare behavior: a provisioned-but-empty database still
+    # needs the schema restored before migrations run.
+    def self.database_initialized?(pool)
+      return pool.with_connection { DataMigrate::RailsHelper.schema_migration.table_exists? } if pool.respond_to?(:with_connection)
 
-      pool.connection
+      DataMigrate::RailsHelper.schema_migration.table_exists?
     end
 
     def self.load_schema_for(db_config)
@@ -329,23 +336,13 @@ module DataMigrate
 
     private_class_method :initialize_missing_databases_with_data_schema,
       :initialize_database_with_schema,
-      :pooled_connection,
+      :database_initialized?,
       :load_schema_for,
       :seeds?,
       :schema_format_for,
       :rails_schema_dump_path_for
 
     private
-
-    def database_exists?(connection)
-      if connection.respond_to?(:database_exists?)  # Rails 7.1+
-        connection.database_exists?
-      else
-        connection.table_exists?(ActiveRecord::SchemaMigration.table_name)
-      end
-    rescue ActiveRecord::NoDatabaseError
-      false
-    end
 
     def primary?(db_config)
       if db_config.respond_to?(:primary?)  # Rails 7.0+

--- a/lib/data_migrate/database_tasks.rb
+++ b/lib/data_migrate/database_tasks.rb
@@ -131,20 +131,25 @@ module DataMigrate
       end
     end
 
-    def schema_dump_path(db_config, format = ActiveRecord.schema_format)
+    def schema_dump_path(db_config, format = nil)
+      format ||= schema_format
       return ENV["DATA_SCHEMA"] if ENV["DATA_SCHEMA"]
 
       # We only require a schema.rb file for the primary database
-      return unless db_config.primary?
+      return unless primary?(db_config)
 
-      File.join(File.dirname(ActiveRecord::Tasks::DatabaseTasks.schema_dump_path(db_config, format)), schema_file_type)
+      File.join(File.dirname(rails_schema_dump_path_for(db_config, format)), schema_file_type)
     end
 
     # Override this method from `ActiveRecord::Tasks::DatabaseTasks`
     # to ensure that the sha saved in ar_internal_metadata table
     # is from the original schema.rb file
     def schema_sha1(file)
-      ActiveRecord::Tasks::DatabaseTasks.schema_dump_path(ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: "primary"))
+      primary_db_config = ActiveRecord::Base.configurations.configs_for(
+        env_name: ActiveRecord::Tasks::DatabaseTasks.env,
+        name: "primary"
+      )
+      rails_schema_dump_path_for(primary_db_config, schema_format)
     end
 
     def forward(step = 1)
@@ -220,36 +225,115 @@ module DataMigrate
     end
 
     def self.prepare_all_with_data
+      seed = initialize_missing_databases_with_data_schema
+
+      migrate_with_data
+
+      if dump_schema_after_migration?
+        each_current_configuration(env) do |db_config|
+          with_temporary_pool(db_config) do
+            ActiveRecord::Tasks::DatabaseTasks.dump_schema(
+              db_config,
+              schema_format_for(db_config)
+            )
+          end
+        end
+
+        # data:dump should run against the primary environment connection,
+        # not whichever temporary pool was used most recently.
+        migration_class.establish_connection(env.to_sym)
+        DataMigrate::Tasks::DataMigrateTasks.dump
+      end
+
+      return unless seed
+
+      # seeds should run against the primary environment connection. data:dump can
+      # also switch ActiveRecord::Base to an override configuration.
+      migration_class.establish_connection(env.to_sym)
+      load_seed
+    end
+
+    def self.initialize_missing_databases_with_data_schema
       seed = false
 
       each_current_configuration(env) do |db_config|
-        next unless primary?(db_config)
-
-        with_temporary_pool(db_config) do |pool|
-          connection = pool.respond_to?(:lease_connection) ? pool.lease_connection : pool.connection
-          unless database_exists?(connection)
-            create(db_config)
-            if File.exist?(schema_dump_path(db_config))
-              load_schema(db_config, schema_format, nil)
-              load_schema_current(
-                :ruby,
-                ENV["DATA_SCHEMA"]
-              )
-            end
-
-            seed = true
-          end
-
-          migrate_with_data
-          if dump_schema_after_migration?
-            dump_schema(db_config)
-            DataMigrate::Tasks::DataMigrateTasks.dump
-          end
-        end
+        seed = initialize_database_with_schema(db_config) || seed
       end
 
-      load_seed if seed
+      seed
     end
+
+    def self.initialize_database_with_schema(db_config)
+      seeded_database = false
+
+      with_temporary_pool(db_config) do |pool|
+        connection = pooled_connection(pool)
+        next if database_exists?(connection)
+
+        create(db_config)
+        load_schema_for(db_config)
+        seeded_database = seeds?(db_config)
+      end
+
+      seeded_database
+    end
+
+    def self.pooled_connection(pool)
+      return pool.lease_connection if pool.respond_to?(:lease_connection)
+
+      pool.connection
+    end
+
+    def self.load_schema_for(db_config)
+      schema_format = schema_format_for(db_config)
+      schema_path = rails_schema_dump_path_for(db_config, schema_format)
+      return unless schema_path && File.exist?(schema_path)
+
+      # Call Rails' database task module directly. Invoking the mixed-in helper
+      # here can misresolve structure_load_flags during fresh setup.
+      ActiveRecord::Tasks::DatabaseTasks.load_schema(
+        db_config,
+        schema_format,
+        nil
+      )
+
+      return unless primary?(db_config)
+
+      data_schema_path = schema_dump_path(db_config)
+      return unless data_schema_path && File.exist?(data_schema_path)
+
+      # Loading the primary data schema file directly keeps the version stamping
+      # on the same connection that just loaded the primary schema.
+      load(data_schema_path)
+    end
+
+    def self.seeds?(db_config)
+      return db_config.seeds? if db_config.respond_to?(:seeds?)
+
+      primary?(db_config)
+    end
+
+    def self.schema_format_for(db_config)
+      return db_config.schema_format if db_config.respond_to?(:schema_format)
+
+      schema_format
+    end
+
+    def self.rails_schema_dump_path_for(db_config, schema_format)
+      if ActiveRecord::Tasks::DatabaseTasks.respond_to?(:schema_dump_path)
+        ActiveRecord::Tasks::DatabaseTasks.schema_dump_path(db_config, schema_format)
+      else
+        ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.name, schema_format)
+      end
+    end
+
+    private_class_method :initialize_missing_databases_with_data_schema,
+      :initialize_database_with_schema,
+      :pooled_connection,
+      :load_schema_for,
+      :seeds?,
+      :schema_format_for,
+      :rails_schema_dump_path_for
 
     private
 

--- a/spec/data_migrate/database_tasks_spec.rb
+++ b/spec/data_migrate/database_tasks_spec.rb
@@ -104,110 +104,154 @@ describe DataMigrate::DatabaseTasks do
     end
 
     describe :prepare_all_with_data do
-      let(:db_config) do
+      let(:primary_db_config) do
         ActiveRecord::DatabaseConfigurations::HashConfig.new(
           'test',
           'primary',
           adapter: "sqlite3",
           database: "spec/db/test.db"
-        )
+        ).tap do |db_config|
+          db_config.define_singleton_method(:seeds?) { true }
+          db_config.define_singleton_method(:schema_format) { :ruby }
+        end
       end
 
-      let(:pool) { double("ConnectionPool") }
-      let(:connection) { double("Connection") }
+      let(:secondary_db_config) do
+        ActiveRecord::DatabaseConfigurations::HashConfig.new(
+          'test',
+          'secondary',
+          adapter: "sqlite3",
+          database: "spec/db/secondary_test.db"
+        ).tap do |db_config|
+          db_config.define_singleton_method(:seeds?) { false }
+          db_config.define_singleton_method(:schema_format) { :sql }
+        end
+      end
+
+      let(:primary_pool) { double("PrimaryConnectionPool") }
+      let(:secondary_pool) { double("SecondaryConnectionPool") }
+      let(:primary_connection) { double("PrimaryConnection") }
+      let(:secondary_connection) { double("SecondaryConnection") }
+      let(:migration_class) { class_double(ActiveRecord::Base, establish_connection: true) }
+      let(:primary_structure_path) { "spec/db/schema.rb" }
+      let(:secondary_structure_path) { "spec/db/secondary_schema.rb" }
+      let(:primary_data_schema_path) { "spec/db/data_schema.rb" }
+      let(:created_configs) { [] }
 
       before do
-        allow(subject).to receive(:each_current_configuration).and_yield(db_config)
-        allow(subject).to receive(:with_temporary_pool).with(db_config).and_yield(pool)
-        allow(pool).to receive(:lease_connection).and_return(connection)
-        allow(subject).to receive(:schema_dump_path).and_return("db/data_schema.rb")
-        allow(File).to receive(:exist?).and_return(true)
-        allow(subject).to receive(:load_schema)
-        allow(subject).to receive(:load_schema_current)
-        allow(subject).to receive(:migrate_with_data)
-        allow(subject).to receive(:dump_schema)
-        allow(DataMigrate::Tasks::DataMigrateTasks).to receive(:dump)
-        allow(subject).to receive(:load_seed)
+        allow(subject).to receive(:each_current_configuration) do |*_args, &block|
+          block.call(primary_db_config)
+          block.call(secondary_db_config)
+        end
 
-        configurations = ActiveRecord::DatabaseConfigurations.new([db_config])
+        allow(subject).to receive(:with_temporary_pool) do |db_config, &block|
+          pool =
+            if db_config == primary_db_config
+              primary_pool
+            else
+              secondary_pool
+            end
+
+          block.call(pool)
+        end
+
+        allow(primary_pool).to receive(:lease_connection).and_return(primary_connection)
+        allow(secondary_pool).to receive(:lease_connection).and_return(secondary_connection)
+        allow(subject).to receive(:database_exists?).with(primary_connection).and_return(false)
+        allow(subject).to receive(:database_exists?).with(secondary_connection).and_return(false)
+        allow(subject).to receive(:create) { |db_config| created_configs << db_config }
+
+        # Return a path only for the expected per-database format so this spec
+        # fails if prepare_all_with_data resolves schema dumps with the wrong format.
+        if DataMigrate::RailsHelper.rails_version_equal_to_or_higher_than_7_0
+          allow(ActiveRecord::Tasks::DatabaseTasks).to receive(:schema_dump_path) do |db_config, format = nil|
+            if db_config == primary_db_config && format == :ruby
+              primary_structure_path
+            elsif db_config == secondary_db_config && format == :sql
+              secondary_structure_path
+            end
+          end
+        else
+          allow(ActiveRecord::Tasks::DatabaseTasks).to receive(:dump_filename) do |db_name, format = nil|
+            if db_name == primary_db_config.name && format == :ruby
+              primary_structure_path
+            elsif db_name == secondary_db_config.name && format == :sql
+              secondary_structure_path
+            end
+          end
+        end
+
+        allow(File).to receive(:exist?).and_return(false)
+        allow(File).to receive(:exist?).with(primary_structure_path).and_return(true)
+        allow(File).to receive(:exist?).with(secondary_structure_path).and_return(true)
+        allow(File).to receive(:exist?).with(primary_data_schema_path).and_return(true)
+        allow(ActiveRecord::Tasks::DatabaseTasks).to receive(:load_schema)
+        allow(subject).to receive(:load)
+        allow(subject).to receive(:migrate_with_data)
+        allow(subject).to receive(:load_seed)
+        allow(subject).to receive(:migration_class).and_return(migration_class)
+        allow(DataMigrate::Tasks::DataMigrateTasks).to receive(:dump)
+        allow(ActiveRecord::Tasks::DatabaseTasks).to receive(:dump_schema)
+
+        configurations = ActiveRecord::DatabaseConfigurations.new([primary_db_config, secondary_db_config])
         allow(ActiveRecord::Base).to receive(:configurations).and_return(configurations)
       end
 
-      context "when the database does not exist" do
-        before do
-          allow(subject).to receive(:database_exists?).with(connection).and_return(false)
-          allow_any_instance_of(ActiveRecord::Tasks::DatabaseTasks).to receive(:create)
-            .and_return(true)
-        end
+      it "initializes current databases and only loads data schema for the primary database" do
+        subject.prepare_all_with_data
 
-        it "creates the database" do
-          expect_any_instance_of(ActiveRecord::Tasks::DatabaseTasks).to receive(:create)
-            .with(db_config)
-          subject.prepare_all_with_data
-        end
-
-        it "loads the schema" do
-          expect(subject).to receive(:load_schema).with(
-            db_config,
-            subject.send(:schema_format),
-            nil
-          )
-          subject.prepare_all_with_data
-        end
-
-        it "loads the current data schema" do
-          expect(subject).to receive(:load_schema_current).with(:ruby, ENV["DATA_SCHEMA"])
-          subject.prepare_all_with_data
-        end
-
-        it "runs migrations with data" do
-          expect(subject).to receive(:migrate_with_data)
-          subject.prepare_all_with_data
-        end
-
-        it "dumps the schema after migration" do
-          expect(subject).to receive(:dump_schema).with(db_config)
-          expect(DataMigrate::Tasks::DataMigrateTasks).to receive(:dump)
-          subject.prepare_all_with_data
-        end
-
-        it "loads seed data" do
-          expect(subject).to receive(:load_seed)
-          subject.prepare_all_with_data
-        end
+        expect(created_configs).to contain_exactly(primary_db_config, secondary_db_config)
+        expect(ActiveRecord::Tasks::DatabaseTasks).to have_received(:load_schema).with(primary_db_config, :ruby, nil)
+        expect(ActiveRecord::Tasks::DatabaseTasks).to have_received(:load_schema).with(secondary_db_config, :sql, nil)
+        expect(ActiveRecord::Tasks::DatabaseTasks).to have_received(:dump_schema).with(primary_db_config, :ruby)
+        expect(ActiveRecord::Tasks::DatabaseTasks).to have_received(:dump_schema).with(secondary_db_config, :sql)
+        expect(subject).to have_received(:load).with(primary_data_schema_path).once
+        expect(subject).to have_received(:migrate_with_data)
+        expect(DataMigrate::Tasks::DataMigrateTasks).to have_received(:dump)
+        expect(migration_class).to have_received(:establish_connection).with(subject.env.to_sym).twice
+        expect(subject).to have_received(:load_seed)
       end
 
-      context "when the database exists" do
-        before do
-          allow(subject).to receive(:database_exists?).with(connection).and_return(true)
-        end
+      it "restores the primary connection before seeding when data dump uses an override connection" do
+        DataMigrate.config.db_configuration = { adapter: "sqlite3", database: "spec/db/override.db" }
 
-        it "does not create the database" do
-          expect(ActiveRecord::Tasks::DatabaseTasks).not_to receive(:create)
-          subject.prepare_all_with_data
-        end
+        subject.prepare_all_with_data
 
-        it "does not load the schema" do
-          expect(subject).not_to receive(:load_schema)
-          expect(subject).not_to receive(:load_schema_current)
-          subject.prepare_all_with_data
-        end
+        expect(migration_class).to have_received(:establish_connection).with(subject.env.to_sym).twice
+      ensure
+        DataMigrate.config.db_configuration = nil
+      end
 
-        it "runs migrations with data" do
-          expect(subject).to receive(:migrate_with_data)
-          subject.prepare_all_with_data
-        end
+      it "still seeds but skips schema and data dumps when dump_schema_after_migration is false" do
+        allow(subject).to receive(:dump_schema_after_migration?).and_return(false)
 
-        it "dumps the schema after migration" do
-          expect(subject).to receive(:dump_schema).with(db_config)
-          expect(DataMigrate::Tasks::DataMigrateTasks).to receive(:dump)
-          subject.prepare_all_with_data
-        end
+        subject.prepare_all_with_data
 
-        it "does not load seed data" do
-          expect(subject).not_to receive(:load_seed)
-          subject.prepare_all_with_data
-        end
+        expect(created_configs).to contain_exactly(primary_db_config, secondary_db_config)
+        expect(ActiveRecord::Tasks::DatabaseTasks).to have_received(:load_schema).with(primary_db_config, :ruby, nil)
+        expect(ActiveRecord::Tasks::DatabaseTasks).to have_received(:load_schema).with(secondary_db_config, :sql, nil)
+        expect(ActiveRecord::Tasks::DatabaseTasks).not_to have_received(:dump_schema)
+        expect(subject).to have_received(:load).with(primary_data_schema_path).once
+        expect(subject).to have_received(:migrate_with_data)
+        expect(DataMigrate::Tasks::DataMigrateTasks).not_to have_received(:dump)
+        expect(migration_class).to have_received(:establish_connection).with(subject.env.to_sym).once
+        expect(subject).to have_received(:load_seed)
+      end
+
+      it "skips setup work for existing databases but still migrates and dumps" do
+        allow(subject).to receive(:database_exists?).with(primary_connection).and_return(true)
+        allow(subject).to receive(:database_exists?).with(secondary_connection).and_return(true)
+
+        subject.prepare_all_with_data
+
+        expect(created_configs).to be_empty
+        expect(ActiveRecord::Tasks::DatabaseTasks).not_to have_received(:load_schema)
+        expect(subject).not_to have_received(:load)
+        expect(subject).to have_received(:migrate_with_data)
+        expect(ActiveRecord::Tasks::DatabaseTasks).to have_received(:dump_schema).with(primary_db_config, :ruby)
+        expect(ActiveRecord::Tasks::DatabaseTasks).to have_received(:dump_schema).with(secondary_db_config, :sql)
+        expect(DataMigrate::Tasks::DataMigrateTasks).to have_received(:dump)
+        expect(subject).not_to have_received(:load_seed)
       end
     end
   end

--- a/spec/data_migrate/database_tasks_spec.rb
+++ b/spec/data_migrate/database_tasks_spec.rb
@@ -103,6 +103,28 @@ describe DataMigrate::DatabaseTasks do
       end
     end
 
+    describe :database_initialized? do
+      let(:pool) { double("ConnectionPool") }
+      let(:connection) { double("Connection") }
+      let(:schema_migration) { double("SchemaMigration", table_name: "schema_migrations") }
+
+      it "checks schema initialization against the temporary pool connection" do
+        allow(DataMigrate::RailsHelper).to receive(:schema_migration).and_return(schema_migration)
+        allow(pool).to receive(:with_connection).and_yield(connection)
+        allow(connection).to receive(:data_source_exists?).with("schema_migrations").and_return(true)
+
+        expect(subject.send(:database_initialized?, pool)).to be(true)
+      end
+
+      it "treats provisioned databases without schema_migrations as uninitialized" do
+        allow(DataMigrate::RailsHelper).to receive(:schema_migration).and_return(schema_migration)
+        allow(pool).to receive(:with_connection).and_yield(connection)
+        allow(connection).to receive(:data_source_exists?).with("schema_migrations").and_return(false)
+
+        expect(subject.send(:database_initialized?, pool)).to be(false)
+      end
+    end
+
     describe :prepare_all_with_data do
       let(:primary_db_config) do
         ActiveRecord::DatabaseConfigurations::HashConfig.new(

--- a/spec/data_migrate/database_tasks_spec.rb
+++ b/spec/data_migrate/database_tasks_spec.rb
@@ -130,8 +130,6 @@ describe DataMigrate::DatabaseTasks do
 
       let(:primary_pool) { double("PrimaryConnectionPool") }
       let(:secondary_pool) { double("SecondaryConnectionPool") }
-      let(:primary_connection) { double("PrimaryConnection") }
-      let(:secondary_connection) { double("SecondaryConnection") }
       let(:migration_class) { class_double(ActiveRecord::Base, establish_connection: true) }
       let(:primary_structure_path) { "spec/db/schema.rb" }
       let(:secondary_structure_path) { "spec/db/secondary_schema.rb" }
@@ -139,6 +137,8 @@ describe DataMigrate::DatabaseTasks do
       let(:created_configs) { [] }
 
       before do
+        initialization_checks = Hash.new(0)
+
         allow(subject).to receive(:each_current_configuration) do |*_args, &block|
           block.call(primary_db_config)
           block.call(secondary_db_config)
@@ -155,10 +155,12 @@ describe DataMigrate::DatabaseTasks do
           block.call(pool)
         end
 
-        allow(primary_pool).to receive(:lease_connection).and_return(primary_connection)
-        allow(secondary_pool).to receive(:lease_connection).and_return(secondary_connection)
-        allow(subject).to receive(:database_exists?).with(primary_connection).and_return(false)
-        allow(subject).to receive(:database_exists?).with(secondary_connection).and_return(false)
+        allow(subject).to receive(:database_initialized?) do |pool|
+          initialization_checks[pool] += 1
+          raise ActiveRecord::NoDatabaseError if initialization_checks[pool] == 1
+
+          false
+        end
         allow(subject).to receive(:create) { |db_config| created_configs << db_config }
 
         # Return a path only for the expected per-database format so this spec
@@ -212,6 +214,13 @@ describe DataMigrate::DatabaseTasks do
         expect(subject).to have_received(:load_seed)
       end
 
+      it "loads secondary databases through Rails' sql schema loader when their schema format is sql" do
+        subject.prepare_all_with_data
+
+        expect(ActiveRecord::Tasks::DatabaseTasks).to have_received(:load_schema).with(secondary_db_config, :sql, nil)
+        expect(subject).to have_received(:load).with(primary_data_schema_path).once
+      end
+
       it "restores the primary connection before seeding when data dump uses an override connection" do
         DataMigrate.config.db_configuration = { adapter: "sqlite3", database: "spec/db/override.db" }
 
@@ -238,9 +247,9 @@ describe DataMigrate::DatabaseTasks do
         expect(subject).to have_received(:load_seed)
       end
 
-      it "skips setup work for existing databases but still migrates and dumps" do
-        allow(subject).to receive(:database_exists?).with(primary_connection).and_return(true)
-        allow(subject).to receive(:database_exists?).with(secondary_connection).and_return(true)
+      it "skips setup work for initialized databases but still migrates and dumps" do
+        allow(subject).to receive(:database_initialized?).with(primary_pool).and_return(true)
+        allow(subject).to receive(:database_initialized?).with(secondary_pool).and_return(true)
 
         subject.prepare_all_with_data
 
@@ -252,6 +261,31 @@ describe DataMigrate::DatabaseTasks do
         expect(ActiveRecord::Tasks::DatabaseTasks).to have_received(:dump_schema).with(secondary_db_config, :sql)
         expect(DataMigrate::Tasks::DataMigrateTasks).to have_received(:dump)
         expect(subject).not_to have_received(:load_seed)
+      end
+
+      it "loads schema for provisioned databases that are not yet initialized" do
+        allow(subject).to receive(:database_initialized?).with(primary_pool).and_return(false)
+        allow(subject).to receive(:database_initialized?).with(secondary_pool).and_return(false)
+
+        subject.prepare_all_with_data
+
+        expect(created_configs).to be_empty
+        expect(ActiveRecord::Tasks::DatabaseTasks).to have_received(:load_schema).with(primary_db_config, :ruby, nil)
+        expect(ActiveRecord::Tasks::DatabaseTasks).to have_received(:load_schema).with(secondary_db_config, :sql, nil)
+        expect(subject).to have_received(:load).with(primary_data_schema_path).once
+        expect(subject).to have_received(:migrate_with_data)
+        expect(ActiveRecord::Tasks::DatabaseTasks).to have_received(:dump_schema).with(primary_db_config, :ruby)
+        expect(ActiveRecord::Tasks::DatabaseTasks).to have_received(:dump_schema).with(secondary_db_config, :sql)
+        expect(DataMigrate::Tasks::DataMigrateTasks).to have_received(:dump)
+        expect(subject).to have_received(:load_seed)
+      end
+
+      it "creates missing databases before restoring schema" do
+        subject.prepare_all_with_data
+
+        expect(created_configs).to contain_exactly(primary_db_config, secondary_db_config)
+        expect(ActiveRecord::Tasks::DatabaseTasks).to have_received(:load_schema).with(primary_db_config, :ruby, nil)
+        expect(ActiveRecord::Tasks::DatabaseTasks).to have_received(:load_schema).with(secondary_db_config, :sql, nil)
       end
     end
   end


### PR DESCRIPTION
Updated data_migrate’s db:prepare:with_data initialization check so it inspects the schema_migrations table through the temporary pool connection for the database currently being prepared.

This avoids the nested connection checkout path that can raise ActiveRecord::ConnectionNotEstablished on newer Rails immediately after a database is created.

We needed this because db:prepare was working, but db:prepare:with_data was failing during the “is this database already initialized?” check.

The fix keeps the existing Rails-compatible behavior intact: missing databases are still created, and databases that already exist but have not been initialized still have schema restored before migrations run.